### PR TITLE
Adding a new node to bypass the error caused by all-zero mask in BatchCropFromMaskAdvanced

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1864,7 +1864,7 @@ class FilterZeroMasksAndCorrespondingImages:
         
         if also_process_images:
             non_zero_mask_images_out = torch.stack(non_zero_mask_images, dim=0)
-            zero_mask_images_out = torch.stack(zero_mask_images, dim=0)
+            zero_mask_images_out = torch.stack(zero_mask_images, dim=0) if len(zero_mask_images) > 0 else None
         else:
             non_zero_mask_images_out = zero_mask_images_out = None
 

--- a/nodes.py
+++ b/nodes.py
@@ -1897,15 +1897,12 @@ class InsertImageBatchByIndexes:
     CATEGORY = "KJNodes"
     
     def insert(self, images, images_to_insert, insert_indexes):
-        """_summary_
-
-        Args:
-            images (_type_): _description_
-            images_to_insert (_type_): _description_
-            insert_indexes (_type_): _description_
+        """
+        This node is designed to be use with node FilterZeroMasksAndCorrespondingImages
+        It inserts the images_to_insert into images according to insert_indexes
 
         Returns:
-            _type_: _description_
+            images_after_insert: updated original images with origonal sequence order 
         """
         
         images_after_insert = images


### PR DESCRIPTION
Added a new node: FilterZeroMasksAndCorrespondingImages

Function:
        Filter out all the empty (i.e. all zero) mask in masks
        Also filter out all the corresponding images in original_images by indexes if provide

The reason I added this node is because node: BatchCropFromMaskAdvanced cannot handle the cases when there is all zero mask in the input: masks
(e.g. when using face detector but it couldn't find any face in the image, then nodes.py Line:1709 in function: calculate_bbox will throw error)

So we can place this new node right before the BatchCropFromMaskAdvanced to filter out the all zero mask and corresponding images before the futher process, this is ideal because: 
        1. It allow automation without worry about error mentioned above 
        2. It reduces computation by ignore the images with empty mask