### PR TITLE
improved intrinsic lora postprocessing

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -3650,10 +3650,9 @@ class Intrinsic_lora_sampling:
             imax = image_out.max()
             imin = image_out.min()
             image_out = (image_out-imin)/(imax-imin)
-            image_out = 0.299 * image_out[..., 0] + 0.587 * image_out[..., 1] + 0.114 * image_out[..., 2]
-            image_out = image_out.unsqueeze(-1).repeat(1, 1, 1, 3)
+            image_out = torch.max(image_out, dim=3, keepdim=True)[0].repeat(1, 1, 1, 3)
         elif task == 'surface normals':
-            image_out = image_out.clamp(-1.,1.)
+            image_out = F.normalize(image_out * 2 - 1, dim=3) / 2 + 0.5
             image_out = 1.0 - image_out
         else:
             image_out = image_out.clamp(-1.,1.)


### PR DESCRIPTION
For depth, desaturating the VAE output can leave artifacts on sharp edges, in the form of blue spots that get desaturated into dark spots. Taking the max of the 3 channels instead helps to reduce those artifacts. 
![depth_comparison](https://github.com/kijai/ComfyUI-KJNodes/assets/143970342/1b12c0e3-ce27-44df-8bf5-c973fb6817a1)

For normals, clamping results in some detail getting lost, and also doesn't enforce the values into valid surface normals, which should be a normalized unit vector.
![normal_comparison](https://github.com/kijai/ComfyUI-KJNodes/assets/143970342/01759e24-d8ba-4562-96a2-78ed9314edde)
