### PR TITLE
add a switch to disable the prefix "Set_" and "Get_"

### DIFF
--- a/web/js/setgetnodes.js
+++ b/web/js/setgetnodes.js
@@ -2,7 +2,7 @@ import { app } from "../../../scripts/app.js";
 import { ComfyWidgets } from '../../../scripts/widgets.js';
 //based on diffus3's SetGet: https://github.com/diffus3/ComfyUI-extensions
 
-let isPrefixEnabled = false;
+let isPrefixEnabled = true;
 
 // Nodes that allow you to tunnel connections for cleaner graphs
 function setColorAndBgColor(type) {

--- a/web/js/setgetnodes.js
+++ b/web/js/setgetnodes.js
@@ -2,6 +2,8 @@ import { app } from "../../../scripts/app.js";
 import { ComfyWidgets } from '../../../scripts/widgets.js';
 //based on diffus3's SetGet: https://github.com/diffus3/ComfyUI-extensions
 
+let isPrefixEnabled = false;
+
 // Nodes that allow you to tunnel connections for cleaner graphs
 function setColorAndBgColor(type) {
     const colorMap = {
@@ -57,7 +59,7 @@ app.registerExtension({
 					(s, t, u, v, x) => {
 						node.validateName(node.graph);
 						if(this.widgets[0].value !== ''){
-							this.title = "Set_" + this.widgets[0].value;
+							this.title = (isPrefixEnabled ? "Set_" : "") + this.widgets[0].value;
 						}
 						this.update();
 						this.properties.previousName = this.widgets[0].value;
@@ -96,7 +98,7 @@ app.registerExtension({
 							const type = fromNode.outputs[link_info.origin_slot].type;
 						
 							if (this.title === "Set"){
-								this.title = "Set_" + type;	
+								this.title = (isPrefixEnabled ? "Set_" : "") + type;	
 							}
 							if (this.widgets[0].value === '*'){
 								this.widgets[0].value = type	
@@ -278,7 +280,7 @@ app.registerExtension({
 						let linkType = (setter.inputs[0].type);
 						
 						this.setType(linkType);
-						this.title = "Get_" + setter.widgets[0].value;
+						this.title = (isPrefixEnabled ? "Get_" : "") + setter.widgets[0].value;
 						
 						if (app.ui.settings.getSettingValue("KJNodes.nodeAutoColor")){
 							setColorAndBgColor.call(this, linkType);	


### PR DESCRIPTION
I put the Get node on the left side of the group, representing the input of the group, and the Set node on the right side of the group, representing the output of the group. Therefore the prefixes Set_ and Get_ can be removed from node title.

<img width="810" alt="image" src="https://github.com/kijai/ComfyUI-KJNodes/assets/19872828/dcf1ca10-2d10-4e6f-9302-054eea86b693">
