### PR TITLE
Fix a bug that causes comfy to hang

### DIFF
--- a/web/js/setgetnodes.js
+++ b/web/js/setgetnodes.js
@@ -249,7 +249,7 @@ app.registerExtension({
 					},
 					{
 						values: () => {
-                            const setterNodes = graph._nodes.filter((otherNode) => otherNode.type == 'SetNode');
+                            const setterNodes = node.graph._nodes.filter((otherNode) => otherNode.type == 'SetNode');
                             return setterNodes.map((otherNode) => otherNode.widgets[0].value).sort();
                         }
 					}


### PR DESCRIPTION
This fix solves a recurring bug that causes comfy to hang when loading large graphs with many GetNodes and SetNodes. 

The error stack for that bug looks like this:

Uncaught ReferenceError: graph is not defined
    values http://localhost:4321/extensions/ComfyUI-KJNodes/js/setgetnodes.js:252
    drawNodeWidgets http://localhost:4321/lib/litegraph.core.js:9932
    drawNode http://localhost:4321/lib/litegraph.core.js:8776
    drawNode http://localhost:4321/extensions/core/snapToGrid.js:86
    drawNode http://localhost:4321/extensions/ComfyUI-Custom-Scripts/js/snapToGrid.js:32
    drawNode http://localhost:4321/scripts/app.js:1220
    drawFrontCanvas http://localhost:4321/lib/litegraph.core.js:7827
    draw http://localhost:4321/lib/litegraph.core.js:7742
    renderFrame http://localhost:4321/lib/litegraph.core.js:5809

graph is somehow not defined yet when that code runs. When taking the graph object from node.graph, it's safe and I couldn't reproduce this bug, it seems solved. 