### PR TITLE
Install requirements on each launch

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,6 @@
+import subprocess
 from .nodes import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS
 
+subprocess.run(['pip', 'install', '-r', 'requirements.txt'])
 WEB_DIRECTORY = "./web"
 __all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS", "WEB_DIRECTORY"]


### PR DESCRIPTION
At [Thinkdiffusion](https://thinkdiffusion.com), we use fresh session for every machine launch. On every new session, KJNodes fails due to dependencies are not available. 

- Updated __init__.py to install requirements.txt on each launch. 