### PR TITLE
Display Get/Set nodes connections: when selected, draw links between GetNodes & SetNode

### DIFF
--- a/web/js/setgetnodes.js
+++ b/web/js/setgetnodes.js
@@ -41,6 +41,7 @@ app.registerExtension({
 		class SetNode {
 			defaultVisibility = true;
 			serialize_widgets = true;
+			drawConnection = false;
 			constructor() {
 				if (!this.properties) {
 					this.properties = {
@@ -213,6 +214,49 @@ app.registerExtension({
 					}
 				})
 			}
+			onSelected() {
+				this.drawConnection = true;
+			}
+			onDeselected() {
+				this.drawConnection = false;
+			}
+			onDrawForeground(ctx, lGraphCanvas) {
+				if (this.drawConnection) {
+					this._drawVirtualLinks(lGraphCanvas, ctx);
+				}
+			}
+			onDrawCollapsed(ctx, lGraphCanvas) {
+				if (this.drawConnection) {
+					this._drawVirtualLinks(lGraphCanvas, ctx);
+				}
+			}
+			_drawVirtualLinks(lGraphCanvas, ctx) {
+				const getters = this.findGetters(this.graph);
+				if (!getters?.length) return;
+				// draw the virtual connection from SetNode to GetNode
+				let start_node_slotpos = [
+				this.size[0],
+				LiteGraph.NODE_TITLE_HEIGHT * 0.5,
+				];
+				for (const getter of getters) {
+				let end_node_slotpos = this.getConnectionPos(false, 0);
+				end_node_slotpos = [
+					getter.pos[0] - end_node_slotpos[0] + this.size[0],
+					getter.pos[1] - end_node_slotpos[1],
+				];
+				lGraphCanvas.renderLink(
+					ctx,
+					start_node_slotpos,
+					end_node_slotpos,
+					null,
+					false,
+					null,
+					"#FFF",
+					LiteGraph.RIGHT,
+					LiteGraph.LEFT
+				);
+				}
+			}
 		}
 
 		LiteGraph.registerNodeType(
@@ -233,6 +277,7 @@ app.registerExtension({
 
 			defaultVisibility = true;
 			serialize_widgets = true;
+			drawConnection = false;
 
 			constructor() {
 				if (!this.properties) {
@@ -266,7 +311,7 @@ app.registerExtension({
 				) {
 					this.validateLinks();	
 				}
-			
+
 				this.setName = function(name) {
 					node.widgets[0].value = name;
 					node.onRename();
@@ -336,6 +381,42 @@ app.registerExtension({
 				}
 			}
 			onAdded(graph) {
+			}
+			onSelected() {
+				this.drawConnection = true;
+			}
+			onDeselected() {
+				this.drawConnection = false;
+			}
+			onDrawForeground(ctx, lGraphCanvas) {
+				if (this.drawConnection) {
+					this._drawVirtualLink(lGraphCanvas, ctx);
+				}
+			}
+			onDrawCollapsed(ctx, lGraphCanvas) {
+				if (this.drawConnection) {
+					this._drawVirtualLink(lGraphCanvas, ctx);
+				}
+			}
+			_drawVirtualLink(lGraphCanvas, ctx) {
+				const setter = this.findSetter(this.graph);
+				if (!setter) return;
+				// draw the virtual connection from SetNode to GetNode
+				let start_node_slotpos = setter.getConnectionPos(false, 0);
+				start_node_slotpos = [
+					start_node_slotpos[0] - this.pos[0],
+					start_node_slotpos[1] - this.pos[1],
+				];
+				let end_node_slotpos = [0, -LiteGraph.NODE_TITLE_HEIGHT * 0.5];
+				lGraphCanvas.renderLink(
+					ctx,
+					start_node_slotpos,
+					end_node_slotpos,
+					null,
+					false,
+					null,
+					"#FFF"
+				);
 			}
 		}
 


### PR DESCRIPTION
By adding `onDrawForeground` & `onDrawCollapsed` callback methods to `GetNode`s/`SetNode`s, they are able to draw virtual links to their corresponding upper/down-stream nodes.

And with `onSelected` and `onDeselected` callback methods, a flag `drawConnection` is toggled. Those virtual links are controlled by the flag so that they appear only when the node is selected.

Examples:

- Select a `GetNode`, draw link to the upstream `SetNode`.

![GetSetNodesConnetion](https://github.com/kijai/ComfyUI-KJNodes/assets/28984159/7c076dcd-50fa-4cf7-9399-252f32b2cea1)

- Select a `SetNode`, draw all links to downstream `GetNode`s.

![GetSetNodesConnetions](https://github.com/kijai/ComfyUI-KJNodes/assets/28984159/26329372-e4d7-40d6-bdb9-5b936b73551a)


