### PR TITLE
ImageAndMaskPreview node mask_color widget fix and hexadecimal color support

### DIFF
--- a/nodes/image_nodes.py
+++ b/nodes/image_nodes.py
@@ -873,9 +873,9 @@ nodes for example.
             mask_image = mask.reshape((-1, 1, mask.shape[-2], mask.shape[-1])).movedim(1, -1).expand(-1, -1, -1, 3).clone()
 
             color_list = list(map(int, mask_color.split(', ')))
-            mask_image[:, :, :, 0] = color_list[0] // 255 # Red channel
-            mask_image[:, :, :, 1] = color_list[1] // 255 # Green channel
-            mask_image[:, :, :, 2] = color_list[2] // 255 # Blue channel
+            mask_image[:, :, :, 0] = color_list[0] / 255 # Red channel
+            mask_image[:, :, :, 1] = color_list[1] / 255 # Green channel
+            mask_image[:, :, :, 2] = color_list[2] / 255 # Blue channel
             
             preview, = ImageCompositeMasked.composite(self, image, mask_image, 0, 0, True, mask_adjusted)
         if pass_through:

--- a/nodes/image_nodes.py
+++ b/nodes/image_nodes.py
@@ -872,7 +872,11 @@ nodes for example.
             mask_adjusted = mask * mask_opacity
             mask_image = mask.reshape((-1, 1, mask.shape[-2], mask.shape[-1])).movedim(1, -1).expand(-1, -1, -1, 3).clone()
 
-            color_list = list(map(int, mask_color.split(', ')))
+            if ',' in mask_color:
+                color_list = np.clip([int(channel) for channel in mask_color.split(',')], 0, 255) # RGB format
+            else:
+                mask_color = mask_color.lstrip('#')
+                color_list = [int(mask_color[i:i+2], 16) for i in (0, 2, 4)] # Hex format
             mask_image[:, :, :, 0] = color_list[0] / 255 # Red channel
             mask_image[:, :, :, 1] = color_list[1] / 255 # Green channel
             mask_image[:, :, :, 2] = color_list[2] / 255 # Blue channel


### PR DESCRIPTION
Swapped floor division (resulting in only 8 possible colors) for true division.
![colorfix](https://github.com/kijai/ComfyUI-KJNodes/assets/40643258/b0649961-f2dd-4d5c-bbe5-ce6f082525ab)
While I was at it I added support for hexadecimal color codes.
![hexadecimal](https://github.com/kijai/ComfyUI-KJNodes/assets/40643258/b24a61db-8eb0-47d5-be69-967735b4da26)
I also clipped the range of the RGB values and converted it to a list comprehension to match the hexadecimal version. Let me know if you'd prefer them as maps, bit presumptuous of me but I found the hexadecimal one cleaner this way.