### PR TITLE
Fix ImagePadForOutpaintTargetSize

### DIFF
--- a/nodes/image_nodes.py
+++ b/nodes/image_nodes.py
@@ -1030,8 +1030,8 @@ class ImagePadForOutpaintTargetSize:
 
     def expand_image(self, image, target_width, target_height, feathering, upscale_method, mask=None):
         B, H, W, C = image.size()
-        new_height = 0
-        new_width = 0
+        new_height = H
+        new_width = W
          # Calculate the scaling factor while maintaining aspect ratio
         scaling_factor = min(target_width / W, target_height / H)
         


### PR DESCRIPTION
There is an error in the code: 
If scale factor is equal 1, then padding should calculated as difference between target and current sizes. Now padding is just target size.