### PR TITLE
Enable handling of sub-steps in LeapfusionHunyuanI2V patch method

### DIFF
--- a/nodes/nodes.py
+++ b/nodes/nodes.py
@@ -2250,7 +2250,17 @@ class LeapfusionHunyuanI2V:
             def unet_wrapper(apply_model, args):
                 steps = args["c"]["transformer_options"]["sample_sigmas"]
                 inp, timestep, c = args["input"], args["timestep"], args["c"]
-                current_step_index = (steps == timestep).nonzero().item()
+                matched_step_index = (steps == timestep).nonzero()
+                if len(matched_step_index) > 0:
+                    current_step_index = matched_step_index.item()
+                else:
+                    for i in range(len(steps) - 1):
+                        # walk from beginning of steps until crossing the timestep
+                        if (steps[i] - timestep) * (steps[i + 1] - timestep) <= 0:
+                            current_step_index = i
+                            break
+                    else:
+                        current_step_index = 0
                 current_percent = current_step_index / (len(steps) - 1)
                 if samples is not None:
                     if start_percent <= current_percent <= end_percent:


### PR DESCRIPTION
Some custom samplers, like the many RES4LYF samplers, perform denoising sub-steps that may not align with the current "sample_sigmas" schedule. This will cause an error if used with the logic in the LeapfusionHunyuanI2V node:

```
  File "H:\AppsDir\git\ComfyBase\ComfyUI\custom_nodes\ComfyUI-KJNodes\nodes\nodes.py", line 2253, in unet_wrapper
    current_step_index = (steps == timestep).nonzero().item()
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: a Tensor with 0 elements cannot be converted to Scalar
```

This small change will prevent an error when using LeapfusionHunyuanI2V with sub-steps when the "timestep" value does not exactly match any of the "sample_sigmas" values. It will still only change the enabled/disabled state of the patch at a full step and should work on both descending and ascending sigmas values.

The condition
```
matched_step_index = (steps == timestep).nonzero()
if len(matched_step_index) > 0:
     current_step_index = matched_step_index.item()
```
ensures that this change won't affect any samplers that would otherwise not cause an error.