### PR TITLE
Add TorchCompileModelHyVideo node

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -166,6 +166,7 @@ NODE_CONFIG = {
     "CheckpointLoaderKJ": {"class": CheckpointLoaderKJ, "name": "CheckpointLoaderKJ"},
     "DiffusionModelLoaderKJ": {"class": DiffusionModelLoaderKJ, "name": "Diffusion Model Loader KJ"},
     "TorchCompileModelFluxAdvanced": {"class": TorchCompileModelFluxAdvanced, "name": "TorchCompileModelFluxAdvanced"},
+    "TorchCompileModelHyVideo": {"class": TorchCompileModelHyVideo, "name": "TorchCompileModelHyVideo"},
     "TorchCompileVAE": {"class": TorchCompileVAE, "name": "TorchCompileVAE"},
     "TorchCompileControlNet": {"class": TorchCompileControlNet, "name": "TorchCompileControlNet"},
     "PatchModelPatcherOrder": {"class": PatchModelPatcherOrder, "name": "Patch Model Patcher Order"},


### PR DESCRIPTION
This PR adds a "TorchCompileModelHyVideo" node for use with HunyuanVideo based on the existing TorchCompileModelFluxAdvanced and the torch.compile settings node from HunyuanVideoWrapper. This allows using torch.compile with HunyuanVideo in native ComfyUI while benefiting from LoRA when using "Patch Model Patcher Order" node. I tried to follow existing style as much as possible. I apologize for the other one I closed, I got slightly ahead of myself and forgot something lol. Cheers and thanks for your hard work on this stuff!