### PR TITLE
Support comma separated types with get/set nodes

### DIFF
--- a/web/js/setgetnodes.js
+++ b/web/js/setgetnodes.js
@@ -449,7 +449,7 @@ app.registerExtension({
 					if (this.outputs[0].type !== '*' && this.outputs[0].links) {
 						this.outputs[0].links.filter(linkId => {
 							const link = node.graph.links[linkId];
-							return link && (link.type !== this.outputs[0].type && link.type !== '*');
+							return link && (!link.type.split(",").includes(this.outputs[0].type) && link.type !== '*');
 						}).forEach(linkId => {
 							node.graph.removeLink(linkId);
 						});


### PR DESCRIPTION
See also: LiteGraph.isValidConnection. This would potentially allow for a cleaner more future proof implementation, but I'm not knowledgeable about what edge cases necessitate the link validation in KJNodes beyond trusting LiteGraph