### PR TITLE
Add Get/SetNode to end of list in context menu

### DIFF
--- a/web/js/contextmenu.js
+++ b/web/js/contextmenu.js
@@ -34,7 +34,7 @@ app.registerExtension({
 	async beforeRegisterNodeDef(nodeType, nodeData, app) {
 		if (nodeData.input && nodeData.input.required) {
 			addMenuHandler(nodeType, function (_, options) {
-				options.unshift(
+				options.push(
 					{
 					content: "Add GetNode",
 					callback: () => {addNode("GetNode", this, { side:"left", offset: 30});}


### PR DESCRIPTION
Can we add the `Add GetNode`, `Add SetNode` to the end of the context menu list instead of the beginning? I find myself accidentally creating GetNodes every time since it displaces everything else in the context menu. 

Or if you don't like that idea, can it at least be a configurable setting?