### PR TITLE
 Ensure that the divisible_by logic is applied even when get_image_size is used as the source of dimensions

### DIFF
--- a/nodes/image_nodes.py
+++ b/nodes/image_nodes.py
@@ -2288,7 +2288,7 @@ highest dimension.
             if height == 0:
                 height = H
       
-        if divisible_by > 1 and get_image_size is None:
+        if divisible_by > 1:
             width = width - (width % divisible_by)
             height = height - (height % divisible_by)
         


### PR DESCRIPTION
Key Changes:
Removed the get_image_size is None condition:
The divisible_by adjustment is now applied regardless of whether get_image_size is used or not.
Adjusted Dimensions:
Even when dimensions are derived from get_image_size, they will now be made divisible by the divisible_by value.
Effects of the Change:
This ensures that the final dimensions of the image are always divisible by the specified divisible_by value, irrespective of how the dimensions were determined (manually or via get_image_size).

We can always set divisible_by to 1 if we want to ignore this function.