### PR TITLE
SplineEditor: Ability to set range of samples in path affected by spline

### DIFF
--- a/nodes/curve_nodes.py
+++ b/nodes/curve_nodes.py
@@ -153,6 +153,8 @@ class SplineEditor:
             "optional": {
                 "min_value": ("FLOAT", {"default": 0.0, "min": -10000.0, "max": 10000.0, "step": 0.01}),
                 "max_value": ("FLOAT", {"default": 1.0, "min": -10000.0, "max": 10000.0, "step": 0.01}),
+                "start_at": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.01}),
+                "end_at": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}),
                 "bg_image": ("IMAGE", ),
             }
         }
@@ -201,7 +203,7 @@ output types:
 
     def splinedata(self, mask_width, mask_height, coordinates, float_output_type, interpolation, 
                    points_to_sample, sampling_method, points_store, tension, repeat_output, 
-                   min_value=0.0, max_value=1.0, bg_image=None):
+                   min_value=0.0, max_value=1.0, start_at=0.0, end_at=1.0, bg_image=None):
         
         coordinates = json.loads(coordinates)
         normalized = []


### PR DESCRIPTION
This is first shot at solution to allow us to influence timing of movement along spline path when used to control eg video generation. (only works for "path" sampling method).

Adds `start_at` and `end_at` ratio to SplineEditor specifying range (0.0 - 1.0) of all samples in path that will be affected by spline:
- samples before start_at will be kept at distance 0
- samples after end_at will be kept at max distance
- samples in between will follow full spline path

Default behavior stays the same as start_at defaults to 0.0 and end_at to 1.0.

**Example usage:**
When generating video eg of cat walking along a shelf and dropping a book, the book should fall very quickly out of screen while the cat continues to walk along:
- the cat should follow its spline path for the whole duration of video - start_at: 0.0 , end_at: 1.0
- the book should stay in place then quickly fall off and again stay in place (outside of screen) - start_at: 0.4 , end_at: 0.6

**Notes:**
Not sure if anyone has requested something like this yet. I can certainly imagine much more sophisticated ways to allow animation along path. This solution just requires minimal changes and shouldn't break anything while allowing at least some flexibility for controlling timing when controlling videos using spline paths (without the need of manually adding control point for each frame).

**Special cases:**
If start_at is higher than end_at they will be swapped internally when sampling (instead of going in reverse as some would expect).