### PR TITLE
Add `channels` to `GetImageSizeAndCount`

### DIFF
--- a/nodes/image_nodes.py
+++ b/nodes/image_nodes.py
@@ -766,8 +766,8 @@ class GetImageSizeAndCount:
             "image": ("IMAGE",),
         }}
 
-    RETURN_TYPES = ("IMAGE","INT", "INT", "INT",)
-    RETURN_NAMES = ("image", "width", "height", "count",)
+    RETURN_TYPES = ("IMAGE","INT", "INT", "INT", "INT",)
+    RETURN_NAMES = ("image", "width", "height", "count", "channels",)
     FUNCTION = "getsize"
     CATEGORY = "KJNodes/image"
     DESCRIPTION = """
@@ -780,9 +780,10 @@ and passes it through unchanged.
         width = image.shape[2]
         height = image.shape[1]
         count = image.shape[0]
+        channels = image.shape[3]
         return {"ui": {
-            "text": [f"{count}x{width}x{height}"]}, 
-            "result": (image, width, height, count) 
+            "text": [f"{count}x{width}x{height}x{channels}"]}, 
+            "result": (image, width, height, count, channels) 
         }
     
 class ImageBatchRepeatInterleaving:

--- a/web/js/jsnodes.js
+++ b/web/js/jsnodes.js
@@ -174,6 +174,7 @@ app.registerExtension({
 					this.outputs[1]["label"] = "width"
 					this.outputs[2]["label"] = "height" 
 					this.outputs[3]["label"] = "count"
+					this.outputs[4]["label"] = "channels"
 					return v;
 				}
 				//const onGetImageSizeExecuted = nodeType.prototype.onExecuted;
@@ -186,6 +187,7 @@ app.registerExtension({
 					this.outputs[1]["label"] = values[1] + " width"
 					this.outputs[2]["label"] = values[2] + " height" 
 					this.outputs[3]["label"] = values[0] + " count" 
+					this.outputs[4]["label"] = values[3] + " channels"
 					return r
 				}
 				break;


### PR DESCRIPTION
About IMAGE's Tensor datatypes
Python datatype torch.Tensor with shape [B,H,W,C]
A batch of B images, height H, width W, with C channels (generally C=3 for RGB).
I think, output the channels's value may be useful, so add this.
![workflow (22)](https://github.com/user-attachments/assets/8fe415eb-e21a-4f60-9b3e-79fdfdafe01e)
