### PR TITLE
Make web paths relative

### DIFF
--- a/web/js/help_popup.js
+++ b/web/js/help_popup.js
@@ -38,10 +38,10 @@ export const loadScript = (
   })
 }
 
-loadScript('/kjweb_async/marked.min.js').catch((e) => {
+loadScript('kjweb_async/marked.min.js').catch((e) => {
   console.log(e)
 })
-loadScript('/kjweb_async/purify.min.js').catch((e) => {
+loadScript('kjweb_async/purify.min.js').catch((e) => {
   console.log(e)
 })
 

--- a/web/js/point_editor.js
+++ b/web/js/point_editor.js
@@ -72,10 +72,10 @@ const create_documentation_stylesheet = () => {
   }
 }
 
-loadScript('/kjweb_async/svg-path-properties.min.js').catch((e) => {
+loadScript('kjweb_async/svg-path-properties.min.js').catch((e) => {
   console.log(e)
 })
-loadScript('/kjweb_async/protovis.min.js').catch((e) => {
+loadScript('kjweb_async/protovis.min.js').catch((e) => {
   console.log(e)
 })
 create_documentation_stylesheet()

--- a/web/js/spline_editor.js
+++ b/web/js/spline_editor.js
@@ -72,10 +72,10 @@ export const loadScript = (
     }
   }
 
-loadScript('/kjweb_async/svg-path-properties.min.js').catch((e) => {
+loadScript('kjweb_async/svg-path-properties.min.js').catch((e) => {
     console.log(e)
 })
-loadScript('/kjweb_async/protovis.min.js').catch((e) => {
+loadScript('kjweb_async/protovis.min.js').catch((e) => {
   console.log(e)
 })
 create_documentation_stylesheet()


### PR DESCRIPTION
This resolves the issue with JS files not being found when ComfyUI is hosted at a sub-URL, for example `https://example.com/comfyui`