### PR TITLE
Add a mask consolidation node

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -41,6 +41,7 @@ NODE_CONFIG = {
     "ResizeMask": {"class": ResizeMask, "name": "Resize Mask"},
     "RoundMask": {"class": RoundMask, "name": "Round Mask"},
     "SeparateMasks": {"class": SeparateMasks, "name": "Separate Masks"},
+    "KJConsolidateMasks": {"class": KJConsolidateMasks, "name": "Consolidate Masks"},
     #images
     "AddLabel": {"class": AddLabel, "name": "Add Label"},
     "ColorMatch": {"class": ColorMatch, "name": "Color Match"},

--- a/__init__.py
+++ b/__init__.py
@@ -41,7 +41,7 @@ NODE_CONFIG = {
     "ResizeMask": {"class": ResizeMask, "name": "Resize Mask"},
     "RoundMask": {"class": RoundMask, "name": "Round Mask"},
     "SeparateMasks": {"class": SeparateMasks, "name": "Separate Masks"},
-    "KJConsolidateMasks": {"class": KJConsolidateMasks, "name": "Consolidate Masks"},
+    "ConsolidateMasksKJ": {"class": ConsolidateMasksKJ, "name": "Consolidate Masks"},
     #images
     "AddLabel": {"class": AddLabel, "name": "Add Label"},
     "ColorMatch": {"class": ColorMatch, "name": "Color Match"},


### PR DESCRIPTION
I found myself needing a way to re-consolidate separated masks in some workflows where gens are run in tiles, so here's a node to do just that. 

The basic idea is to have a large image with tons of masks, then separate them with SeparateMasks, and group them using the optimal tilesize before CropByMask.

It's useful eg. in lamacleaner-style workflows where you might have an optimal tilesize like 1024x1024 but your masks might be small enough that you could fit multiple of them in one tile, avoiding having to run sampling separately for each mask.

I'm not sure if the algorithm for grouping the masks is optimal, but it works well enough for me.