### PR TITLE
Add optimized SageAttention implementations for Hopper / Blackwell GPUs

### DIFF
--- a/nodes/model_optimization_nodes.py
+++ b/nodes/model_optimization_nodes.py
@@ -10,7 +10,7 @@ from comfy.cli_args import args
 from typing import Optional, Tuple
 
 
-sageattn_modes = ["disabled", "auto", "sageattn_qk_int8_pv_fp16_cuda", "sageattn_qk_int8_pv_fp16_triton", "sageattn_qk_int8_pv_fp8_cuda", "sageattn_qk_int8_pv_fp8_cuda++"]
+sageattn_modes = ["disabled", "auto", "sageattn_qk_int8_pv_fp16_cuda", "sageattn_qk_int8_pv_fp16_triton", "sageattn_qk_int8_pv_fp8_cuda", "sageattn_qk_int8_pv_fp8_cuda++", "sageattn_qk_int8_pv_fp8_cuda_sm90", "sageattn_qk_int8_pv_fp8_cuda_sm90++"]
 
 _initialized = False
 _original_functions = {}
@@ -109,6 +109,16 @@ class BaseLoaderKJ:
                     from sageattention import sageattn_qk_int8_pv_fp8_cuda
                     def func(q, k, v, is_causal=False, attn_mask=None, tensor_layout="NHD"):
                         return sageattn_qk_int8_pv_fp8_cuda(q, k, v, is_causal=is_causal, attn_mask=attn_mask, pv_accum_dtype="fp32+fp16", tensor_layout=tensor_layout)
+                    return func
+                elif sage_attention == "sageattn_qk_int8_pv_fp8_cuda_sm90":
+                    from sageattention import sageattn_qk_int8_pv_fp8_cuda_sm90
+                    def func(q, k, v, is_causal=False, attn_mask=None, tensor_layout="NHD"):
+                        return sageattn_qk_int8_pv_fp8_cuda_sm90(q, k, v, is_causal=is_causal, attn_mask=attn_mask, pv_accum_dtype="fp32+fp32", tensor_layout=tensor_layout)
+                    return func
+                elif sage_attention == "sageattn_qk_int8_pv_fp8_cuda_sm90++":
+                    from sageattention import sageattn_qk_int8_pv_fp8_cuda_sm90
+                    def func(q, k, v, is_causal=False, attn_mask=None, tensor_layout="NHD"):
+                        return sageattn_qk_int8_pv_fp8_cuda_sm90(q, k, v, is_causal=is_causal, attn_mask=attn_mask, pv_accum_dtype="fp32", tensor_layout=tensor_layout)
                     return func
 
             sage_func = set_sage_func(sage_attention)


### PR DESCRIPTION
https://github.com/thu-ml/SageAttention/tree/798c791d276f302d4f19246feffa053a9e4c5af5?tab=readme-ov-file#available-apis

> + `sageattn_qk_int8_pv_fp8_cuda_sm90`: INT8 quantization for $QK^\top$ and FP8 for $PV$ using CUDA backend, specifically optimized for Hopper GPUs.

* **sageattn_qk_int8_pv_fp8_cuda_sm90** uses `pv_accum_dtype=fp32+fp32` as balanced solution for speed / accuracy
* **sageattn_qk_int8_pv_fp8_cuda_sm90++** uses `pv_accum_dtype=fp32` for faster speed but less accuracy ("due to the hardware issue, there are only 22 valid bits in the FP32 accumulator")

ref: https://github.com/thu-ml/SageAttention/blob/798c791d276f302d4f19246feffa053a9e4c5af5/sageattention/core.py#L797