### PR TITLE
Fix ImagePadForOutpaintTargetSize mask scaling bug

### DIFF
--- a/nodes/image_nodes.py
+++ b/nodes/image_nodes.py
@@ -1128,22 +1128,17 @@ class ImagePadForOutpaintTargetSize:
             
             # Downscale the image
             image_scaled = common_upscale(image, new_width, new_height, upscale_method, "disabled").movedim(1,-1)
-            if mask is not None:
-                mask_scaled = mask.unsqueeze(0)  # Add an extra dimension for batch size
-                mask_scaled = F.interpolate(mask_scaled, size=(new_height, new_width), mode="nearest")
-                mask_scaled = mask_scaled.squeeze(0)  # Remove the extra dimension after interpolation
-            else:
-                mask_scaled = mask
         else:
             # If downscaling is not needed, use the original image dimensions
             image_scaled = image
-            if mask is not None:
-                # Ensure mask dimensions match image dimensions
-                mask_scaled = mask.unsqueeze(0)  # Add an extra dimension for batch size
-                mask_scaled = F.interpolate(mask_scaled, size=(new_height, new_width), mode="nearest")
-                mask_scaled = mask_scaled.squeeze(0)  # Remove the extra dimension after interpolation
-            else:
-                mask_scaled = mask
+
+        # Ensure mask dimensions match image dimensions
+        if mask is not None:
+            mask_scaled = mask.unsqueeze(0)  # Add an extra dimension for batch size
+            mask_scaled = F.interpolate(mask_scaled, size=(new_height, new_width), mode="nearest")
+            mask_scaled = mask_scaled.squeeze(0)  # Remove the extra dimension after interpolation
+        else:
+            mask_scaled = None
 
         # Calculate how much padding is needed to reach the target dimensions
         pad_top = max(0, (target_height - new_height) // 2)


### PR DESCRIPTION
If the input image and mask have different dimensions, and the target dimension is _larger_ than the image in both width and height, then the resizing of the mask is wrong and the output dimensions for the image and mask mismatch.

Before the fix:
<img width="1496" height="913" alt="image" src="https://github.com/user-attachments/assets/a7a89086-3961-4b3e-b088-6662e23c965f" />

After the fix:
<img width="1604" height="1044" alt="image" src="https://github.com/user-attachments/assets/8bc0782d-818a-4933-9a48-32b50c526a69" />
