### PR TITLE
Fix for SageAttention compatibility with latest ComfyUI

### DIFF
--- a/nodes/model_optimization_nodes.py
+++ b/nodes/model_optimization_nodes.py
@@ -114,7 +114,7 @@ class BaseLoaderKJ:
             sage_func = set_sage_func(sage_attention)
 
             @torch.compiler.disable()
-            def attention_sage(q, k, v, heads, mask=None, attn_precision=None, skip_reshape=False, skip_output_reshape=False, transformer_options=None):
+            def attention_sage(q, k, v, heads, mask=None, attn_precision=None, skip_reshape=False, skip_output_reshape=False, **kwargs):
                 if skip_reshape:
                     b, _, _, dim_head = q.shape
                     tensor_layout="HND"


### PR DESCRIPTION
# Fix SageAttention compatibility with latest ComfyUI

## Problem
ComfyUI commit d7f40442 (Enable Runtime Selection of Attention Functions, Sept 12, 2025), SageAttention throws an error:
```
TypeError: BaseLoaderKJ._patch_modules.<locals>.attention_sage() got an unexpected keyword argument 'transformer_options'
```

## Root cause
Now ComfyUI passes `transformer_options` to all attention functions as part of the runtime selection feature. The `attention_sage` function in model_optimization_nodes.py was using a specific `transformer_options=None` parameter instead of accepting arbitrary keyword arguments.

## Good-enough solution?
Changed the function signature from:
```python
def attention_sage(..., transformer_options=None):
```
to:
```python
def attention_sage(..., **kwargs):
```

## Benefits of this approach...
- Fixes immediate compatibility issue with latest ComfyUI
- Future-proof against additional parameters ComfyUI might add
- Maintains backward compatibility with older ComfyUI versions
- Consistent with ComfyUI's own implementation pattern 
- Follows Python best practices for extensible function signatures (but a bit unspecific unfortunately)

## Tests so far...
- Tested with WAN 2.2 model workflows
- Verified no TypeError occurs
- Confirmed output quality remains unchanged
- Works with both old and new ComfyUI versions

## References
- ComfyUI PR #9639: [Enable Runtime Selection of Attention Functions](https://github.com/comfyanonymous/ComfyUI/pull/9639)
- Related issue discussion: #385

This is a minimal, hopefully safe change that only modifies the function signature to accept additional keyword arguments, to better ensure compatibility without (hopefully) affecting other functionality.