### PR TITLE
Fix LoadVideosFromFolder VideoHelperSuite import in Windows

### DIFF
--- a/nodes/image_nodes.py
+++ b/nodes/image_nodes.py
@@ -3751,7 +3751,29 @@ class LoadVideosFromFolder:
             try:
                 cls.vhs_nodes = importlib.import_module("comfyui-videohelpersuite.videohelpersuite")
             except ImportError:
-                raise ImportError("This node requires ComfyUI-VideoHelperSuite to be installed.")
+                # Fallback to sys.modules search for Windows compatibility
+                import sys
+                vhs_module = None
+                for module_name in sys.modules:
+                    if 'videohelpersuite' in module_name and 'videohelpersuite' in sys.modules[module_name].__dict__:
+                        vhs_module = sys.modules[module_name]
+                        break
+                
+                if vhs_module is None:
+                    # Try direct access to the videohelpersuite submodule
+                    for module_name in sys.modules:
+                        if module_name.endswith('videohelpersuite'):
+                            vhs_module = sys.modules[module_name]
+                            break
+                
+                if vhs_module is not None:
+                    cls.vhs_nodes = vhs_module
+                else:
+                    raise ImportError("This node requires ComfyUI-VideoHelperSuite to be installed.")
+                
+        except ImportError:
+            raise ImportError("This node requires ComfyUI-VideoHelperSuite to be installed.")
+          
     @classmethod
     def INPUT_TYPES(s):
         return {


### PR DESCRIPTION

LoadVideosFromFolder fails on Windows with the error "This node requires ComfyUI-VideoHelperSuite to be installed" even when VideoHelperSuite is properly installed.

For some reason, ComfyUI on Windows loads custom nodes using full file paths as module names (F:\ComfyUI\custom_nodes\ComfyUI-VideoHelperSuite.videohelpersuite), so the standard import paths used in LoadVideosFromFolder fail.
- ` importlib.import_module("ComfyUI-VideoHelperSuite.videohelpersuite")` -- fails on Windows
- `importlib.import_module("comfyui-videohelpersuite.videohelpersuite") `-- fails on Windows

On MacOS, both the full path and standard module names exist in sys.modules, and LoadVideosFromFolder works fine, so this seems to be just a Windows thing.

## Fix

Added a fallback mechanism that searches sys.modules directly when the standard import methods fail. The fix preserves the original import logic (which works on MacOS and probably Linux too) and only uses the fallback when needed.
