### PR TITLE
Rework context menu options for getter nodes.

### DIFF
--- a/web/js/setgetnodes.js
+++ b/web/js/setgetnodes.js
@@ -470,9 +470,8 @@ app.registerExtension({
 				};
 
 				this.goToSetter = function() {
-					const setter = this.findSetter(this.graph);	
-					this.canvas.centerOnNode(setter);
-					this.canvas.selectNode(setter, false);
+					this.canvas.centerOnNode(this.currentSetter);
+					this.canvas.selectNode(this.currentSetter, false);
 				};
 				
 				// This node is purely frontend and does not impact the resulting prompt so should not be serialized
@@ -496,7 +495,8 @@ app.registerExtension({
 			}
 			getExtraMenuOptions(_, options) {
 				let menuEntry = this.drawConnection ? "Hide connections" : "Show connections";
-				
+				this.currentSetter = this.findSetter(this.graph)
+				if (!this.currentSetter) return
 				options.unshift(
 					{
 						content: "Go to setter",
@@ -507,12 +507,9 @@ app.registerExtension({
 					{
 						content: menuEntry,
 						callback: () => {
-							this.currentSetter = this.findSetter(this.graph);
-							if (this.currentSetter.length == 0) return;
-							let linkType = (this.currentSetter.inputs[0].type);	
+							let linkType = (this.currentSetter.inputs[0].type);
 							this.drawConnection = !this.drawConnection;
 							this.slotColor = this.canvas.default_connection_color_byType[linkType]
-							menuEntry = this.drawConnection ? "Hide connections" : "Show connections";
 							this.canvas.setDirty(true, true);
 						},
 					},


### PR DESCRIPTION
Minor cleanup to better handle edge cases.
- The "Go to setter" and toggle connections options aren't displayed if a setter doesn't exist
- Removed an errant `length` check on `currentSetter`
- Removed the unneeded recalculation of `menuEntry`. `getExtraMenuOptions` is called each time a node is right clicked.