### PR TITLE
Fix type resolution at subgraph boundary

### DIFF
--- a/web/js/setgetnodes.js
+++ b/web/js/setgetnodes.js
@@ -103,11 +103,9 @@ app.registerExtension({
 					}
 					//On Connect
 					if (link_info && node.graph && slotType == 1 && isChangeConnect) {
-						const fromNode = node.graph._nodes.find((otherNode) => otherNode.id == link_info.origin_id);
-						
-						if (fromNode && fromNode.outputs && fromNode.outputs[link_info.origin_slot]) {
-							const type = fromNode.outputs[link_info.origin_slot].type;
-						
+						const resolve = link_info.resolve(node.graph)
+						const type = (resolve?.subgraphInput ?? resolve?.output)?.type
+						if (type) {
 							if (this.title === "Set"){
 								this.title = (!disablePrefix ? "Set_" : "") + type;
 							}


### PR DESCRIPTION
Another small fix.  Set nodes need slightly modified logic in order to successfully resolve types of subgraph boundary links.

See also Comfy-Org/ComfyUI_frontend#6135