### PR TITLE
DiffusionModelLoaderKJ: Allow model checkpoints to be used with extra state_dict_input

### DIFF
--- a/nodes/model_optimization_nodes.py
+++ b/nodes/model_optimization_nodes.py
@@ -391,6 +391,14 @@ class DiffusionModelLoaderKJ(BaseLoaderKJ):
     
         sd = comfy.utils.load_torch_file(unet_path)
         if extra_state_dict is not None:
+            # If the model is a checkpoint, strip additional non-diffusion model entries before adding extra state dict
+            from comfy import model_detection
+            diffusion_model_prefix = model_detection.unet_prefix_from_state_dict(sd)
+            if diffusion_model_prefix == "model.diffusion_model.":
+                temp_sd = comfy.utils.state_dict_prefix_replace(sd, {diffusion_model_prefix: ""}, filter_keys=True)
+                if len(temp_sd) > 0:
+                    sd = temp_sd
+            
             extra_sd = comfy.utils.load_torch_file(extra_state_dict)
             sd.update(extra_sd)
             del extra_sd


### PR DESCRIPTION
If an extra_state_dict input is provided but the model file is actually a checkpoint, ComfyUI will strip all additional entries when loading the model, including anything added with the extra_state_dict input. This change allows model checkpoints to be used with extra state dict input by stripping non-diffusion model entries before applying extra state dict so ComfyUI treats it as a raw diffusion model rather than a checkpoint.