### PR TITLE
Replace opencv-python with opencv-python-headless

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ color-matcher
 matplotlib
 huggingface_hub
 mss
-opencv-python
+opencv-python-headless


### PR DESCRIPTION
Since the nodes don't call GUI functions like `cv2.imshow`, we can use the headless Python package, which also prevents dependency issues when run in containers.