### PR TITLE
Allow SomethingToString to accept a string

### DIFF
--- a/nodes/nodes.py
+++ b/nodes/nodes.py
@@ -669,7 +669,7 @@ Converts any type to a string.
 """
 
     def stringify(self, input, prefix="", suffix=""):
-        if isinstance(input, (int, float, bool)):
+        if isinstance(input, (int, float, bool, str)):
             stringified = str(input)
         elif isinstance(input, list):
             stringified = ', '.join(str(item) for item in input)


### PR DESCRIPTION
Why should I want to send a string to SomethingToString, you ask? Because it's a compact node that allows both prefix and suffix, I answer.