### PR TITLE
Added step to ReplaceImagesInBatch

### DIFF
--- a/nodes/image_nodes.py
+++ b/nodes/image_nodes.py
@@ -2145,8 +2145,8 @@ class ReplaceImagesInBatch:
     FUNCTION = "replace"
     CATEGORY = "KJNodes/image"
     DESCRIPTION = """
-Replaces the images in a batch, starting from the specified start index and step,  
-with the replacement images.
+Replaces the images in a batch, starting from the specified start index with step stride,  
+using the replacement images.
 """
 
     @classmethod

--- a/nodes/image_nodes.py
+++ b/nodes/image_nodes.py
@@ -2145,7 +2145,7 @@ class ReplaceImagesInBatch:
     FUNCTION = "replace"
     CATEGORY = "KJNodes/image"
     DESCRIPTION = """
-Replaces the images in a batch, starting from the specified start index,  
+Replaces the images in a batch, starting from the specified start index and step,  
 with the replacement images.
 """
 
@@ -2154,6 +2154,7 @@ with the replacement images.
         return {
             "required": {
                  "start_index": ("INT", {"default": 1,"min": 0, "max": 4096, "step": 1}),
+                 "step": ("INT", {"default": 1,"min": 1, "max": 4096, "step": 1}),
         },
         "optional": {
             "original_images": ("IMAGE",),
@@ -2163,14 +2164,14 @@ with the replacement images.
         }
     } 
     
-    def replace(self, original_images=None, replacement_images=None, start_index=1, original_masks=None, replacement_masks=None):
+    def replace(self, original_images=None, replacement_images=None, start_index=1, step=1, original_masks=None, replacement_masks=None):
         images = None
         masks = None
         
         if original_images is not None and replacement_images is not None:
             if start_index >= len(original_images):
                 raise ValueError("ReplaceImagesInBatch: Start index is out of range")
-            end_index = start_index + len(replacement_images)
+            end_index = start_index + len(replacement_images) * step
             if end_index > len(original_images):
                 raise ValueError("ReplaceImagesInBatch: End index is out of range")
             
@@ -2178,7 +2179,7 @@ with the replacement images.
             if original_images_copy.shape[2] != replacement_images.shape[2] or original_images_copy.shape[3] != replacement_images.shape[3]:
                 replacement_images = common_upscale(replacement_images.movedim(-1, 1), original_images_copy.shape[1], original_images_copy.shape[2], "lanczos", "center").movedim(1, -1)
             
-            original_images_copy[start_index:end_index] = replacement_images
+            original_images_copy[start_index:end_index:step] = replacement_images
             images = original_images_copy
         else:
             images = torch.zeros((1, 64, 64, 3))
@@ -2186,7 +2187,7 @@ with the replacement images.
         if original_masks is not None and replacement_masks is not None:
             if start_index >= len(original_masks):
                 raise ValueError("ReplaceImagesInBatch: Start index is out of range")
-            end_index = start_index + len(replacement_masks)
+            end_index = start_index + len(replacement_masks) * step
             if end_index > len(original_masks):
                 raise ValueError("ReplaceImagesInBatch: End index is out of range")
 
@@ -2194,7 +2195,7 @@ with the replacement images.
             if original_masks_copy.shape[1] != replacement_masks.shape[1] or original_masks_copy.shape[2] != replacement_masks.shape[2]:
                 replacement_masks = common_upscale(replacement_masks.unsqueeze(1), original_masks_copy.shape[1], original_masks_copy.shape[2], "nearest-exact", "center").squeeze(0)
                 
-            original_masks_copy[start_index:end_index] = replacement_masks
+            original_masks_copy[start_index:end_index:step] = replacement_masks
             masks = original_masks_copy
         else:
             masks = torch.zeros((1, 64, 64))


### PR DESCRIPTION
This is useful for VACE

My pipeline:
1. Generate a short seed fragment → Video A
2. Use Video A as conditioning to create a sparse video sequence with stride of 2-3 frames → Video B
3. Synthesize final video in chunks using Video B as seed. (That's why I need a step)
4. Merge the chunks.

This process is stable enough and allows exceeding VRAM limits.
