### PR TITLE
Update image_nodes.py

### DIFF
--- a/nodes/image_nodes.py
+++ b/nodes/image_nodes.py
@@ -176,7 +176,7 @@ Saves an image and mask as .PNG with the mask as the alpha channel.
         def file_counter():
             max_counter = 0
             # Loop through the existing files
-            for existing_file in os.listdir(full_output_folder):
+            for existing_file in sorted(os.listdir(full_output_folder)):
                 # Check if the file matches the expected format
                 match = re.fullmatch(fr"{filename}_(\d+)_?\.[a-zA-Z0-9]+", existing_file)
                 if match:
@@ -2981,7 +2981,7 @@ class LoadImagesFromFolderKJ:
                         except OSError:
                             pass
         else:
-            for file in os.listdir(folder):
+            for file in sorted(os.listdir(folder)):
                 if any(file.lower().endswith(ext) for ext in valid_extensions):
                     path = os.path.join(folder, file)
                     try:
@@ -3043,7 +3043,7 @@ class LoadImagesFromFolderKJ:
                     if any(file.lower().endswith(ext) for ext in valid_extensions):
                         image_paths.append(os.path.join(root, file))
         else:
-            for file in os.listdir(folder):
+            for file in sorted(os.listdir(folder)):
                 if any(file.lower().endswith(ext) for ext in valid_extensions):
                     image_paths.append(os.path.join(folder, file))
 
@@ -3964,7 +3964,7 @@ class LoadVideosFromFolder:
             raise ImportError("This node requires ComfyUI-VideoHelperSuite to be installed.")
         videos_list = []
         filenames = []
-        for f in os.listdir(kwargs['video']):
+        for f in sorted(os.listdir(kwargs['video'])):
             if os.path.isfile(os.path.join(kwargs['video'], f)):
                 file_parts = f.split('.')
                 if len(file_parts) > 1 and (file_parts[-1].lower() in ['webm', 'mp4', 'mkv', 'gif', 'mov']):


### PR DESCRIPTION
sorted() is needed around os.listdir for proper linux file sorting.

The reason your files are not in order is that os.listdir() returns filenames in an arbitrary order (usually based on how they are stored in the file system's inode table), not alphabetically or numerically. On Windows, os.listdir sometimes appears sorted due to how NTFS works, but on Ubuntu (Linux), the raw directory listing is almost never sorted by name. The Fix
You need to sort the list of files before iterating through them. Change this line:
code
Python
for f in os.listdir(kwargs['video']):
To this:
code
Python
for f in sorted(os.listdir(kwargs['video'])):