### PR TITLE
Add None checks to prevent warnings in path resolution

### DIFF
--- a/nodes/image_nodes.py
+++ b/nodes/image_nodes.py
@@ -2963,9 +2963,9 @@ class LoadImagesFromFolderKJ:
 
     @classmethod
     def IS_CHANGED(cls, folder, **kwargs):
-        if not os.path.isabs(folder) and args.base_directory:
+        if folder and not os.path.isabs(folder) and args.base_directory:
             folder = os.path.join(args.base_directory, folder)
-        if not os.path.isdir(folder):
+        if not folder or not os.path.isdir(folder):
             return float("NaN")
         
         valid_extensions = ['.jpg', '.jpeg', '.png', '.webp', '.tga']
@@ -3033,11 +3033,11 @@ class LoadImagesFromFolderKJ:
     CATEGORY = "KJNodes/image"
     DESCRIPTION = """Loads images from a folder into a batch, images are resized and loaded into a batch."""
 
-    def load_images(self, folder, width, height, image_load_cap, start_index, keep_aspect_ratio, include_subfolders=False):
-        if not os.path.isabs(folder) and args.base_directory:
-            folder = os.path.join(args.base_directory, folder)      
-        if not os.path.isdir(folder):
-            raise FileNotFoundError(f"Folder '{folder} cannot be found.'")
+    def load_images(self, folder, width, height, image_load_cap, start_index, keep_aspect_ratio, include_subfolders=False):    
+        if folder and not os.path.isabs(folder) and args.base_directory:
+            folder = os.path.join(args.base_directory, folder)
+        if not folder or not os.path.isdir(folder):
+            raise FileNotFoundError(f"Folder '{folder}' cannot be found.")
         
         valid_extensions = ['.jpg', '.jpeg', '.png', '.webp', '.tga']
         image_paths = []
@@ -3339,7 +3339,7 @@ class SaveStringKJ:
         filename_prefix += self.prefix_append
         
         full_output_folder, filename, counter, subfolder, filename_prefix = folder_paths.get_save_image_path(filename_prefix, self.output_dir)
-        if not os.path.isabs(output_folder) and args.base_directory:
+        if output_folder and not os.path.isabs(output_folder) and args.base_directory:
             output_folder = os.path.join(args.base_directory, output_folder)
         if output_folder != "output":
             if not os.path.exists(output_folder):
@@ -3966,7 +3966,7 @@ class LoadVideosFromFolder:
     FUNCTION = "load_video"
 
     def load_video(self, output_type, grid_max_columns, add_label=False, **kwargs):
-        if not os.path.isabs(kwargs['video']) and args.base_directory:
+        if kwargs.get('video') and not os.path.isabs(kwargs['video']) and args.base_directory:
             kwargs['video'] = os.path.join(args.base_directory, kwargs['video'])
             
         if self.vhs_nodes is None:


### PR DESCRIPTION
Previous pr #451 introduced harmless console warnings. Oops.
`WARNING: expected str, bytes or os.PathLike object, not NoneType`

This pr prevents the warnings.