### PR TITLE
Fix BytesIO import error caused by comfy_api.latest.io

### DIFF
--- a/nodes/curve_nodes.py
+++ b/nodes/curve_nodes.py
@@ -7,6 +7,8 @@ from ..utility.utility import pil2tensor, tensor2pil
 import folder_paths
 import io
 import base64
+from io import BytesIO
+
 
 def parse_color(color):
     if isinstance(color, str) and ',' in color:
@@ -309,7 +311,7 @@ output types:
         else:
             transform = transforms.ToPILImage()
             image = transform(bg_image[0].permute(2, 0, 1))
-            buffered = io.BytesIO()
+            buffered = BytesIO()
             image.save(buffered, format="JPEG", quality=75)
 
             # Encode the image bytes to a Base64 string
@@ -1526,7 +1528,7 @@ you can clear the image from the context menu by right clicking on the canvas
         else:
             transform = transforms.ToPILImage()
             image = transform(bg_image[0].permute(2, 0, 1))
-            buffered = io.BytesIO()
+            buffered = BytesIO()
             image.save(buffered, format="JPEG", quality=75)
 
             # Step 3: Encode the image bytes to a Base64 string

--- a/nodes/image_nodes.py
+++ b/nodes/image_nodes.py
@@ -12,6 +12,8 @@ import re
 import json
 import importlib
 from PIL.PngImagePlugin import PngInfo
+from io import BytesIO
+
 try:
     import cv2
 except:
@@ -3378,7 +3380,7 @@ class FastPreview:
     def preview(self, image, format, quality):        
         pil_image = to_pil_image(image[0].permute(2, 0, 1))
 
-        with io.BytesIO() as buffered:
+        with BytesIO() as buffered:
             pil_image.save(buffered, format=format, quality=quality)
             img_bytes = buffered.getvalue()
 

--- a/nodes/nodes.py
+++ b/nodes/nodes.py
@@ -11,6 +11,7 @@ from nodes import MAX_RESOLUTION
 from comfy.utils import common_upscale, ProgressBar, load_torch_file
 from comfy.comfy_types.node_typing import IO
 from comfy_api.latest import io
+from io import BytesIO
 
 script_directory = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 folder_paths.add_model_folder_path("kjnodes_fonts", os.path.join(script_directory, "fonts"))
@@ -1632,7 +1633,7 @@ or a .txt file with RealEstate camera intrinsics and coordinates, in a 3D plot.
         
         plt.title('')
         plt.draw()
-        buf = io.BytesIO()
+        buf = BytesIO()
         plt.savefig(buf, format='png', bbox_inches='tight', pad_inches=0)
         buf.seek(0)
         img = Image.open(buf)


### PR DESCRIPTION
### Problem
Some nodes import `io` from `comfy_api.latest` but later use `io.BytesIO`,
which is not provided by `comfy_api.latest._io_public`, causing runtime errors:

module 'comfy_api.latest._io_public' has no attribute 'BytesIO'

### Fix
- Import `BytesIO` from Python standard library `io`
- Replace `io.BytesIO` with `BytesIO` in affected nodes
- Keep existing `comfy_api.latest.io` usage unchanged to avoid breaking API behavior

### Files affected
- nodes/nodes.py
- nodes/curve_nodes.py
- nodes/image_nodes.py

Tested on Python 3.12 with latest ComfyUI.
