### PR TITLE
Add shift operators to Simple Calculator KJ node

### DIFF
--- a/nodes/nodes.py
+++ b/nodes/nodes.py
@@ -2729,7 +2729,7 @@ class SimpleCalculatorKJ:
 
         # Allowed operations
         allowed_operators = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,  ast.Div: operator.truediv,
-            ast.Pow: operator.pow, ast.USub: operator.neg, ast.UAdd: operator.pos,
+            ast.Pow: operator.pow, ast.USub: operator.neg, ast.UAdd: operator.pos, ast.LShift: operator.lshift, ast.RShift, operator.rshift,
         }
 
         # Allowed functions


### PR DESCRIPTION
I'm using sillytavern to generate a seed that is passed to a comfyui workflow that includes running through seedvr2. Seeds are generally 64bit, however seedvr2 only accepts 32bit seeds. I solve for this by shifting right by 32 and taking the upper 32 bits. So I added the bitshift operators here. Should probably add other operators like and/or/xor/not but I'm too lazy to do that.