### PR TITLE
Fix incorrect resize for images with EXIF orientation.

### DIFF
--- a/nodes/image_nodes.py
+++ b/nodes/image_nodes.py
@@ -2838,6 +2838,7 @@ class LoadAndResizeImage:
         
         import node_helpers
         img = node_helpers.pillow(Image.open, image_path)
+        img = ImageOps.exif_transpose(img)
 
         # Process the background_color
         if background_color:


### PR DESCRIPTION
PIL does not apply EXIF rotation automatically, so img.size could differ from the displayed orientation. Applying ImageOps.exif_transpose before resizing prevents width/height mismatch and image stretching.