### PR TITLE
Fix: GrowMaskWithBlur uint8 overflow on empty segmentation mask

### DIFF
--- a/nodes/mask_nodes.py
+++ b/nodes/mask_nodes.py
@@ -1007,7 +1007,7 @@ class GrowMaskWithBlur:
         current_expand = expand
         for m in tqdm(growmask, desc="Expanding/Contracting Mask"):
             output = m.unsqueeze(0).unsqueeze(0).to(main_device)  # Add batch and channel dims for kornia
-            if abs(round(current_expand)) > 0:
+            if abs(round(current_expand)) > 0 and output.max() > 0:
                 # Create kernel - kornia expects kernel on same device as input
                 if tapered_corners:
                     kernel = torch.tensor([[0, 1, 0],


### PR DESCRIPTION
## Problem

When an upstream segmentation node finds no objects, it returns an empty mask. `GrowMaskWithBlur`'s `expand_mask` method passes this to `kornia.morphology.dilation()`, which calls `F.pad()` on a uint8 tensor with a border value that overflows, crashing with:

`RuntimeError: value cannot be converted to type uint8_t without overflow`

This is consistently reproducible whenever segmentation returns no results.

## Fix

Added an `output.max() > 0` guard to the existing condition on line 1010. When the mask is empty (all zeros), morphology operations are skipped entirely and the empty mask flows through unchanged.