### PR TITLE
Fix JoinStringMulti dynamic input sync

### DIFF
--- a/web/js/jsnodes.js
+++ b/web/js/jsnodes.js
@@ -228,14 +228,34 @@ app.registerExtension({
 							this.inputs = [];
 						}
 						const target_number_of_inputs = this.widgets.find(w => w.name === "inputcount")["value"];
-						if (target_number_of_inputs === this.inputs.length) return; // already set, do nothing
-			
-						if (target_number_of_inputs < this.inputs.length) {
-							for (let i = this.inputs.length; i >= this.inputs_offset + target_number_of_inputs; i--)
-								this.removeInput(i);
-						} else {
-							for (let i = this.inputs.length + 1 - this.inputs_offset; i <= target_number_of_inputs; ++i)
-								this.addInput(`string_${i}`, this._type);
+						const desired_names = new Set(
+							Array.from({ length: target_number_of_inputs }, (_, i) => `string_${i + 1}`)
+						);
+						const current_string_names = new Set(
+							this.inputs
+								.filter(input => /^string_\d+$/.test(input?.name))
+								.map(input => input.name)
+						);
+
+						const already_synced =
+							current_string_names.size === desired_names.size &&
+							[...desired_names].every(name => current_string_names.has(name));
+						if (already_synced) return;
+
+						// Remove stray dynamic inputs first so count updates don't drift when non-string inputs exist.
+						for (const name of current_string_names) {
+							if (!desired_names.has(name)) {
+								const slot_index = this.inputs.findIndex(input => input?.name === name);
+								if (slot_index !== -1) {
+									this.removeInput(slot_index);
+								}
+							}
+						}
+						for (let i = 1; i <= target_number_of_inputs; i++) {
+							const name = `string_${i}`;
+							if (!this.inputs.some(input => input?.name === name)) {
+								this.addInput(name, this._type);
+							}
 						}
 					});
 				}


### PR DESCRIPTION
  ## Summary

  This PR fixes a UI/input-sync issue in `JoinStringMulti` where changing `inputcount` repeatedly can leave the visible
  inputs out of sync with the configured count (missing or mismatched `string_*` sockets).

  - Affected node: `JoinStringMulti`
  - File changed: `web/js/jsnodes.js`

  ## Problem

  When `inputcount` is changed multiple times and "Update inputs" is clicked, the node may end up with inputs that do
  not match the expected `string_1...string_N` set.

  Observed behavior:
  - Socket count can drift after repeated increase/decrease operations.
  - Socket names/order may not match expected `string_1...string_N`.
  - Existing logic relies on `this.inputs.length`, which is fragile when non-dynamic or stale slots are present.

  ## Root Cause

  The previous update logic used index/count-based add/remove behavior:
  - It compared `target_number_of_inputs` with `this.inputs.length`.
  - It removed inputs by index ranges and added by count assumptions.

  This can become inaccurate when the input list includes non-target sockets or leftover dynamic state, causing early-
  return or wrong removals/additions.

  ## Fix

  Replaced count-based mutation with **name-based reconciliation** for dynamic string slots:

  - Build desired socket-name set: `string_1 ... string_N`
  - Collect current dynamic string sockets using `^string_\d+$`
  - If current and desired sets are equal, return early
  - Remove stray dynamic `string_*` sockets not in desired set
  - Add missing `string_*` sockets up to `inputcount`

  This makes updates deterministic and idempotent, and avoids drift caused by raw input length assumptions.

  ## Why this is safe

  - Scope is limited to `JoinStringMulti` frontend node behavior.
  - No backend execution logic changed.
  - Non-`string_*` inputs are not touched by the reconciliation logic.

  ## Manual Validation

  Tested with repeated update cycles:
  - `2 -> 8 -> 3 -> 10 -> 2`
  - Repeated clicking "Update inputs" at each step

  Result:
  - Inputs consistently match `inputcount`
  - Socket names remain correctly aligned (`string_1...string_N`)
  - No mismatch/drift observed after repeated changes