### PR TITLE
fix ModelSaveKJ

### DIFF
--- a/nodes/nodes.py
+++ b/nodes/nodes.py
@@ -2182,7 +2182,7 @@ class ModelSaveKJ:
         model_management.load_models_gpu(load_models, force_patch_weights=True)
         default_prefix = "model.diffusion_model."
 
-        sd = model.model.state_dict_for_saving(None, None, None)
+        sd = model.state_dict_for_saving(None, None, None)
 
         new_sd = {}
         for k in sd:


### PR DESCRIPTION
Fixed error

```
Traceback (most recent call last):
  File "/home/ubuntu/ComfyUI/execution.py", line 524, in execute
    output_data, output_ui, has_subgraph, has_pending_tasks = await get_output_data(prompt_id, unique_id, obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data)
                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/ComfyUI/execution.py", line 333, in get_output_data
    return_values = await _async_map_node_over_list(prompt_id, unique_id, obj, input_data_all, obj.FUNCTION, allow_interrupt=True, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/ComfyUI/execution.py", line 307, in _async_map_node_over_list
    await process_inputs(input_dict, i)
  File "/home/ubuntu/ComfyUI/execution.py", line 295, in process_inputs
    result = f(**inputs)
  File "/home/ubuntu/ComfyUI/custom_nodes/comfyui-kjnodes/nodes/nodes.py", line 2185, in save
    sd = model.model.state_dict_for_saving(None, None, None)
  File "/home/ubuntu/ComfyUI/comfy/model_base.py", line 343, in state_dict_for_saving
    unet_state_dict = self.model_config.process_unet_state_dict_for_saving(unet_state_dict)
  File "/home/ubuntu/ComfyUI/comfy/supported_models_base.py", line 112, in process_unet_state_dict_for_saving
    return utils.state_dict_prefix_replace(state_dict, replace_prefix)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/ComfyUI/comfy/utils.py", line 195, in state_dict_prefix_replace
    replace = list(map(lambda a: (a, "{}{}".format(replace_prefix[rp], a[len(rp):])), filter(lambda a: a.startswith(rp), state_dict.keys())))
                                                                                                                         ^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'keys'
```

I checked ComfyUI built-in "CheckpointSave" node, it calls the "model" directly, not the "model.model". So I'm guessing the fix should be OK.