### PR TITLE
fix: PreviewImageOrMask — graceful fallback for older ComfyUI version…

### DIFF
--- a/nodes/image_nodes.py
+++ b/nodes/image_nodes.py
@@ -35,7 +35,7 @@ from fractions import Fraction
 import node_helpers
 import folder_paths
 
-from ..utility.utility import string_to_color
+from ..utility.utility import string_to_color, schema_extra
 
 try:
     from server import PromptServer, BinaryEventTypes
@@ -4357,7 +4357,7 @@ class EncodeVideoComponents(io.ComfyNode):
         ]
         return io.Schema(
             node_id="EncodeVideoComponents",
-            search_aliases=["video to latent", "encode video", "vae encode video"],
+            **schema_extra(search_aliases=["video to latent", "encode video", "vae encode video"]),
             display_name="Encode Video Components",
             category="KJNodes/image",
             description="Extracts video frames, resizes them, and encodes with a VAE directly, avoiding storing the full image tensor.",
@@ -4605,7 +4605,7 @@ class DecodeAndSaveVideo(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="DecodeAndSaveVideo",
-            search_aliases=["video to latent", "decode video"],
+            **schema_extra(search_aliases=["video to latent", "decode video"]),
             display_name="Decode and Save Video",
             category="KJNodes/image",
             description="Decodes video frames and audio from latent representations, combines them, and saves as a video file, without keeping intermediate images in memory.",
@@ -4773,21 +4773,12 @@ class DecodeAndSaveVideo(io.ComfyNode):
 class PreviewImageOrMask(io.ComfyNode):
     @classmethod
     def define_schema(cls):
-        _extra = {}
-        try:
-            import inspect
-            if "essentials_category" in inspect.signature(io.Schema.__init__).parameters:
-                _extra["essentials_category"] = "Basics"
-            if "search_aliases" in inspect.signature(io.Schema.__init__).parameters:
-                _extra["search_aliases"] = ["output"]
-        except Exception:
-            pass
         return io.Schema(
             node_id="PreviewImageOrMask",
             display_name="Preview Image Or Mask",
             category="image",
             description="Previews the input images or masks.",
-            **_extra,
+            **schema_extra(essentials_category="Basics", search_aliases=["output"]),
             inputs=[
                 io.MultiType.Input("input", [io.Image, io.Mask], tooltip="The image or mask to preview."),
             ],

--- a/nodes/nodes.py
+++ b/nodes/nodes.py
@@ -20,6 +20,8 @@ import comfy.latent_formats
 import node_helpers
 from io import BytesIO
 
+from ..utility.utility import schema_extra
+
 script_directory = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 folder_paths.add_model_folder_path("kjnodes_fonts", os.path.join(script_directory, "fonts"))
 
@@ -2867,7 +2869,7 @@ Calculator node that evaluates a mathematical expression using inputs a and b.
     Supported functions: abs(), round(), min(), max(), pow(), sqrt(), sin(), cos(), tan(), log(), log10(), exp(), floor(), ceil()  
     Supported constants: pi, euler, True, False  
 """,
-            search_aliases=["math", "arithmetic", "expression", "logic"],
+            **schema_extra(search_aliases=["math", "arithmetic", "expression", "logic"]),
             inputs=[
                 io.String.Input("expression", default="a + b", multiline=True),
                 io.Autogrow.Input("variables", template=template),

--- a/utility/utility.py
+++ b/utility/utility.py
@@ -3,6 +3,17 @@ import numpy as np
 from PIL import Image, ImageColor
 from typing import Union, List
 import logging
+import inspect
+
+def schema_extra(**kwargs):
+    # Filter io.Schema kwargs to only those supported by the current ComfyUI version.
+    # Older versions lack essentials_category, search_aliases, etc.
+    from comfy_api.latest import io
+    try:
+        params = inspect.signature(io.Schema.__init__).parameters
+    except (ValueError, TypeError):
+        return {}
+    return {k: v for k, v in kwargs.items() if k in params}
 
 # Utility functions from mtb nodes: https://github.com/melMass/comfy_mtb
 def pil2tensor(image: Union[Image.Image, List[Image.Image]]) -> torch.Tensor:


### PR DESCRIPTION
graceful fallback for older ComfyUI versions that don't support `essentials_category` and `search_aliases` kwargs in `io.Schema`

Changed files:
- nodes/image_nodes.py