### PR TITLE
LTXV: Add guide_attention_entries to multi-guide nodes

### DIFF
--- a/nodes/ltxv_nodes.py
+++ b/nodes/ltxv_nodes.py
@@ -1,4 +1,4 @@
-from comfy_extras.nodes_lt import get_noise_mask, LTXVAddGuide
+from comfy_extras.nodes_lt import get_noise_mask, LTXVAddGuide, _append_guide_attention_entry
 import types
 import math
 from typing import Tuple
@@ -96,6 +96,14 @@ class LTXVAddGuideMulti(LTXVAddGuide):
                 scale_factors,
             )
 
+            # Track this guide for per-reference attention control.
+            pre_filter_count = t.shape[2] * t.shape[3] * t.shape[4]
+            guide_latent_shape = list(t.shape[2:])  # [F, H, W]
+            positive, negative = _append_guide_attention_entry(
+                positive, negative, pre_filter_count, guide_latent_shape,
+                strength=strength, latent_start=latent_idx,
+            )
+
         return io.NodeOutput(positive, negative, {"samples": latent_image, "noise_mask": noise_mask})
 
 class LTXVAddGuidesFromBatch(LTXVAddGuide):
@@ -153,6 +161,14 @@ class LTXVAddGuidesFromBatch(LTXVAddGuide):
                         t,
                         strength,
                         scale_factors,
+                    )
+
+                    # Track this guide for per-reference attention control.
+                    pre_filter_count = t.shape[2] * t.shape[3] * t.shape[4]
+                    guide_latent_shape = list(t.shape[2:])  # [F, H, W]
+                    positive, negative = _append_guide_attention_entry(
+                        positive, negative, pre_filter_count, guide_latent_shape,
+                        strength=strength, latent_start=latent_idx,
                     )
                 else:
                     print(f"Warning: Skipping guide at index {i} - conditioning frames exceed latent sequence length")


### PR DESCRIPTION
LTXVAddGuideMulti and LTXVAddGuidesFromBatch now record a guide_attention_entries entry per guide, matching upstream LTXVAddGuide. The latent_start field is needed by downstream consumers like context windows, which process partial slices of the latent and need each guide's absolute start index to locate it within a window.