### PR TITLE
Support loader reconstruction in loader nodes (fixes torch compile)

### DIFF
--- a/nodes/model_optimization_nodes.py
+++ b/nodes/model_optimization_nodes.py
@@ -171,14 +171,11 @@ class CheckpointLoaderKJ():
             args.fast.discard("cublas_ops")
 
         ckpt_path = folder_paths.get_full_path_or_raise("checkpoints", ckpt_name)
-        sd, metadata = comfy.utils.load_torch_file(ckpt_path, return_metadata=True)
-
-        model, clip, vae, _ = comfy.sd.load_state_dict_guess_config(
-            sd,
+        model, clip, vae, _ = comfy.sd.load_checkpoint_guess_config(
+            ckpt_path,
             output_vae=True,
             output_clip=True,
             embedding_directory=folder_paths.get_folder_paths("embeddings"),
-            metadata=metadata,
             model_options=model_options)
 
         if dtype := DTYPE_MAP.get(compute_dtype):

--- a/nodes/model_optimization_nodes.py
+++ b/nodes/model_optimization_nodes.py
@@ -246,10 +246,7 @@ def _load_diffusion_model_kj(unet_path, model_options=None, extra_state_dict=Non
         disable_dynamic=disable_dynamic,
     )
 
-    model.cached_patcher_init = (
-        _load_diffusion_model_kj,
-        (unet_path, model_options, extra_state_dict),
-    )
+    model.cached_patcher_init = (_load_diffusion_model_kj, (unet_path, model_options, extra_state_dict))
     return model
 
 class DiffusionModelLoaderKJ():
@@ -307,11 +304,7 @@ class DiffusionModelLoaderKJ():
 
         unet_path = folder_paths.get_full_path_or_raise("diffusion_models", model_name)
 
-        model = _load_diffusion_model_kj(
-            unet_path,
-            model_options=model_options,
-            extra_state_dict=extra_state_dict,
-        )
+        model = _load_diffusion_model_kj(unet_path, model_options=model_options, extra_state_dict=extra_state_dict)
         if dtype := DTYPE_MAP.get(compute_dtype):
             model.set_model_compute_dtype(dtype)
             model.force_cast_weights = False

--- a/nodes/model_optimization_nodes.py
+++ b/nodes/model_optimization_nodes.py
@@ -230,6 +230,31 @@ class DiffusionModelSelector():
             model_path = folder_paths.get_full_path_or_raise("diffusion_models", model_name)
         return (model_path,)
 
+def _load_diffusion_model_kj(unet_path, model_options=None, extra_state_dict=None, disable_dynamic=False):
+    model_options = {} if model_options is None else dict(model_options)
+
+    sd, metadata = comfy.utils.load_torch_file(unet_path, return_metadata=True)
+    if extra_state_dict is not None:
+        extra_sd = comfy.utils.load_torch_file(extra_state_dict)
+        sd.update(extra_sd)
+        del extra_sd
+
+        diffusion_model_prefix = comfy.sd.model_detection.unet_prefix_from_state_dict(sd)
+        sd = comfy.utils.state_dict_prefix_replace(sd, {diffusion_model_prefix: ""}, filter_keys=False)
+
+    model = comfy.sd.load_diffusion_model_state_dict(
+        sd,
+        model_options=model_options,
+        metadata=metadata,
+        disable_dynamic=disable_dynamic,
+    )
+
+    model.cached_patcher_init = (
+        _load_diffusion_model_kj,
+        (unet_path, model_options, extra_state_dict),
+    )
+    return model
+
 class DiffusionModelLoaderKJ():
     @classmethod
     def INPUT_TYPES(s):
@@ -285,16 +310,11 @@ class DiffusionModelLoaderKJ():
 
         unet_path = folder_paths.get_full_path_or_raise("diffusion_models", model_name)
 
-        sd, metadata = comfy.utils.load_torch_file(unet_path, return_metadata=True)
-        if extra_state_dict is not None:
-            extra_sd = comfy.utils.load_torch_file(extra_state_dict)
-            sd.update(extra_sd)
-            del extra_sd
-
-            diffusion_model_prefix = comfy.sd.model_detection.unet_prefix_from_state_dict(sd)
-            sd = comfy.utils.state_dict_prefix_replace(sd, {diffusion_model_prefix: ""}, filter_keys=False)
-
-        model = comfy.sd.load_diffusion_model_state_dict(sd, model_options=model_options, metadata=metadata)
+        model = _load_diffusion_model_kj(
+            unet_path,
+            model_options=model_options,
+            extra_state_dict=extra_state_dict,
+        )
         if dtype := DTYPE_MAP.get(compute_dtype):
             model.set_model_compute_dtype(dtype)
             model.force_cast_weights = False


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI/issues/13599

Make the KJ loaders implement the reconstructibility protocol of ComfyUI core. This allows these loaders to work for all instances of reconstruction (torch compiler, hooks and the uncoming multi-GPU stuff).

Example test conditions:

Linux, 5090, SDXL + native torch compiler node, KJNnodes loader

<img width="1171" height="782" alt="image" src="https://github.com/user-attachments/assets/6ee36c32-10f8-4e5a-bdd0-e25ef7b1b464" />


Before:

```
^^^
  File "/home/rattus/ComfyUI/execution.py", line 309, in _async_map_node_over_list
    await process_inputs(input_dict, i)
  File "/home/rattus/ComfyUI/execution.py", line 297, in process_inputs
    result = f(**inputs)
             ^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy_api/internal/__init__.py", line 149, in wrapped_func
    return method(locked_class, **inputs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy_api/latest/_io.py", line 1826, in EXECUTE_NORMALIZED
    to_return = cls.execute(*args, **kwargs)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy_extras/nodes_torch_compile.py", line 28, in execute
    m = model.clone(disable_dynamic=True)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/model_patcher.py", line 339, in clone
    raise RuntimeError("Cannot create non-dynamic delegate: cached_patcher_init is not initialized.")
RuntimeError: Cannot create non-dynamic delegate: cached_patcher_init is not initialized.

Prompt executed in 0.25 seconds
```

After:

```
loaded completely; 28356.30 MB usable, 4897.05 MB loaded, full load: True
100%|██████████| 20/20 [00:00<00:00, 40.33it/s]                                  
Model AutoencoderKL prepared for dynamic VRAM loading. 159MB Staged. 0 patches attached.
Prompt executed in 1.58 seconds
```