### PR TITLE
feat(editors): image scales to fit node size + Align to image button

### DIFF
--- a/web/js/editors/editor_base.js
+++ b/web/js/editors/editor_base.js
@@ -236,10 +236,14 @@ export class BaseEditorCanvas {
     this.heightWidget.value = img.height;
     this.onImageResize?.(img);
 
-    // Cap display size, preserving aspect ratio
+    // Cap display size to the current node width if the user has already resized it,
+    // otherwise fall back to maxDisplayDim. This prevents the node from expanding to
+    // fill the image — instead the image scales to fit the node.
+    const nodeCanvasW = Math.max(64, Math.round(this.node.size[0] - 45));
+    const fitDim = Math.min(nodeCanvasW, maxDisplayDim);
     let displayW = img.width, displayH = img.height;
-    if (displayW > maxDisplayDim || displayH > maxDisplayDim) {
-      const scale = maxDisplayDim / Math.max(displayW, displayH);
+    if (displayW > fitDim || displayH > fitDim) {
+      const scale = fitDim / Math.max(displayW, displayH);
       displayW = Math.round(displayW * scale);
       displayH = Math.round(displayH * scale);
     }
@@ -249,7 +253,8 @@ export class BaseEditorCanvas {
       this.height = displayH;
       this.resizeCanvas();
 
-      if (displayW > 256) this.setNodeWidth(displayW + 45);
+      // Only expand the node width if it's narrower than the image — never shrink it
+      if (displayW + 45 > this.node.size[0]) this.setNodeWidth(displayW + 45);
       this.onSizeChanged();
       if (this.node.graph) {
         try { this.node.arrange?.(); } catch (_) {}
@@ -522,20 +527,42 @@ export class BaseEditorCanvas {
     setupMenuItems(node.contextMenu, menuEls);
     document.body.appendChild(node.contextMenu);
 
+    // Shared helper — loads the stored background image into the editor.
+    // alignToImage: if true, resizes the node to fit the image first (old behaviour).
+    //               if false, scales the image to fit the current node size (new behaviour).
+    const _reloadBgImage = (alignToImage) => {
+      const imgData = node.properties.imgData;
+      if (!imgData) return;
+      const img = new Image();
+      img.onload = () => {
+        if (!node.editor) return;
+        if (alignToImage) {
+          // Temporarily lift the node-size cap so processImage can expand the node
+          const savedSize = [node.size[0], node.size[1]];
+          node.setSize([Math.min(img.width, maxDisplayDim) + 45, savedSize[1]]);
+        }
+        node.editor.processImage(img);
+      };
+      if (imgData.base64) {
+        img.src = `data:${imgData.type || 'image/png'};base64,${imgData.base64}`;
+      } else if (imgData.filename) {
+        img.src = `/view?filename=${encodeURIComponent(imgData.filename)}&type=temp&no-cache=${Date.now()}`;
+      }
+    };
+
+    // "Reset canvas" — clears points and re-fits the image to the current node size
     node.addWidget("button", "Reset canvas", null, () => {
       try {
         node.editor = new editorClass(node, true);
-        // If a background image exists, re-apply it to restore correct dimensions
-        const imgData = node.properties.imgData;
-        if (imgData) {
-          const img = new Image();
-          img.onload = () => { if (node.editor) node.editor.processImage(img); };
-          if (imgData.base64) {
-            img.src = `data:${imgData.type || 'image/png'};base64,${imgData.base64}`;
-          } else if (imgData.filename) {
-            img.src = `/view?filename=${encodeURIComponent(imgData.filename)}&type=temp&no-cache=${Date.now()}`;
-          }
-        }
+        _reloadBgImage(false);
+      } catch (error) { console.error(`Error creating ${editorClass.name}:`, error); }
+    });
+
+    // "Align to image" — resizes the node to match the image dimensions (legacy behaviour)
+    node.addWidget("button", "Align to image", null, () => {
+      try {
+        node.editor = new editorClass(node, true);
+        _reloadBgImage(true);
       } catch (error) { console.error(`Error creating ${editorClass.name}:`, error); }
     });
 


### PR DESCRIPTION
## Summary

- When a background image is loaded into a Points/Spline editor node, the node no longer auto-expands to fill the image. Instead the image is downscaled to fit the current node width — users control canvas size by resizing the node manually before loading the image.
- A new **Align to image** button is added alongside **Reset canvas**. It restores the original behaviour: resizes the node to match the image dimensions (capped at `maxDisplayDim`).
- **Reset canvas** now keeps the current node size and fits the image into it.

## Motivation

When connecting a high-resolution image to the Points Editor, the node would expand to 1024px wide and push everything else on the canvas out of the way. This makes it impractical to use in dense workflows. The new behaviour lets you keep the node at any size you prefer.

The `onResize` callback already handled the inverse case correctly (user drags node → canvas rescales to fit). This PR makes image load consistent with that same behaviour.

## Test plan

- [ ] Load a large image (>1024px) into Points Editor — node should not expand
- [ ] Resize node to a small size, load image — image fits inside the node
- [ ] Click **Align to image** — node expands to fit image (legacy behaviour)
- [ ] Click **Reset canvas** — points cleared, image re-fits to current node size
- [ ] Verify points placed before reset are cleared correctly in both buttons
- [ ] Verify behaviour on Spline Editor and any other editors using `BaseEditorCanvas`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)