### PR TITLE
Fix: scope sageattention import to avoid ModuleNotFoundError on sageattn3-only platforms

### DIFF
--- a/nodes/model_optimization_nodes.py
+++ b/nodes/model_optimization_nodes.py
@@ -25,8 +25,8 @@ sageattn_modes = ["disabled", "auto", "sageattn_qk_int8_pv_fp16_cuda", "sageattn
 
 def get_sage_func(sage_attention, allow_compile=False):
     logging.info(f"Using sage attention mode: {sage_attention}")
-    from sageattention import sageattn
     if sage_attention == "auto":
+        from sageattention import sageattn
         def sage_func(q, k, v, is_causal=False, attn_mask=None, tensor_layout="NHD"):
             return sageattn(q, k, v, is_causal=is_causal, attn_mask=attn_mask, tensor_layout=tensor_layout)
     elif sage_attention == "sageattn_qk_int8_pv_fp16_cuda":


### PR DESCRIPTION
## Summary

- Moves \`from sageattention import sageattn\` from unconditional top-level import inside the \`if sage_attention == "auto":\` branch in \`get_sage_func()\`.
- Fixes \`ModuleNotFoundError\` on platforms where only \`sageattn3\` is installed (e.g. NVIDIA GB10 Grace Blackwell).
- The import was previously outside any conditional, causing the module to fail on import even when the \`"auto"\` path wasn't taken.

## Changed Files

- \`nodes/model_optimization_nodes.py\` - moved import into the \`if sage_attention == "auto":\` block.