### PR TITLE
Preview override: Add LTXAV audio preview synced to video

### DIFF
--- a/nodes/preview_override_node.py
+++ b/nodes/preview_override_node.py
@@ -10,6 +10,7 @@ import torch
 
 import comfy.model_management
 import comfy.patcher_extension
+import comfy.utils
 import latent_preview
 from comfy_api.latest import io
 from PIL import Image, ImageOps
@@ -296,6 +297,49 @@ def _ltx_full_vae_decode_to_pil(vae, x0_5d, max_frames=None, stride=1):
     return [Image.fromarray(u8[i]) for i in range(u8.shape[0])]
 
 
+def _decode_audio_waveform(audio_first_stage, ax, target_device):
+    # Decode on first_stage_model directly (VAE pinned to GPU in __call__) to skip comfy
+    # VAE.decode()'s per-step load_models_gpu. first_stage_model.decode gives (B, C, samples).
+    if ax is None or ax.numel() == 0:
+        return None
+    try:
+        ax = ax.to(device=target_device, dtype=torch.float32)
+        waveform = audio_first_stage.decode(ax)
+    except Exception as e:
+        logging.warning(f"[KJ PreviewOverride] audio VAE decode failed: {e}")
+        return None
+    if waveform.ndim == 2:
+        waveform = waveform.unsqueeze(1)  # (B, samples) → (B, 1, samples)
+    if waveform.ndim != 3:
+        return None
+    # Mirror comfy_extras.nodes_audio.vae_decode_audio loudness normalization.
+    std = torch.std(waveform, dim=[1, 2], keepdim=True) * 5.0
+    std[std < 1.0] = 1.0
+    waveform = waveform / std
+    return waveform[0].clamp(-1.0, 1.0).detach().float().cpu()
+
+
+def _encode_wav_b64(waveform_cpu, sample_rate):
+    # 16-bit PCM WAV — browser-native via <audio>, no extra deps. waveform_cpu: (C, samples).
+    if waveform_cpu is None or waveform_cpu.numel() == 0:
+        return None
+    try:
+        import wave
+        channels = waveform_cpu.shape[0]
+        interleaved = (waveform_cpu.transpose(0, 1).contiguous().numpy() * 32767.0)
+        interleaved = np.clip(interleaved, -32768, 32767).astype("<i2")
+        buf = pyio.BytesIO()
+        with wave.open(buf, "wb") as wf:
+            wf.setnchannels(int(channels))
+            wf.setsampwidth(2)
+            wf.setframerate(int(sample_rate))
+            wf.writeframes(interleaved.tobytes())
+        return base64.b64encode(buf.getvalue()).decode("ascii")
+    except Exception as e:
+        logging.warning(f"[KJ PreviewOverride] WAV encode failed: {e}")
+        return None
+
+
 def _is_ltx_latent_format(latent_format):
     return "LTX" in type(latent_format).__name__
 
@@ -337,7 +381,7 @@ def _normalize_ltx_x0(x0, latent_shapes, num_keyframes):
 
 
 class _PreviewOverrideWrapper:
-    def __init__(self, max_resolution, node_id, jpeg_quality, suppress_default, preview_frames=1, preview_fps=12, vae=None):
+    def __init__(self, max_resolution, node_id, jpeg_quality, suppress_default, preview_frames=1, preview_fps=12, vae=None, audio_vae=None):
         self.max_resolution = max_resolution
         self.node_id = str(node_id) if node_id is not None else None
         self.jpeg_quality = jpeg_quality
@@ -345,6 +389,7 @@ class _PreviewOverrideWrapper:
         self.preview_frames = preview_frames
         self.preview_fps = preview_fps
         self.vae = vae
+        self.audio_vae = audio_vae
         self.frames = []
 
     def __call__(self, executor, noise, latent_image, sampler, sigmas, denoise_mask, callback, disable_pbar, seed, latent_shapes):
@@ -383,6 +428,28 @@ class _PreviewOverrideWrapper:
                 ltx_previewer = _LTXWrappedPreviewer(factors, bias, rate=8, taeltx=taeltx)
             except Exception as e:
                 logging.warning(f"[KJ PreviewOverride] LTX previewer setup failed: {e}")
+
+        # Audio preview (LTXAV): >1 latent_shapes means the sampled latent packs an audio
+        # tensor. Pin the audio VAE to GPU for the run; restored in finally.
+        audio_first_stage = None
+        audio_target_device = None
+        audio_restore_device = None
+        audio_sample_rate = 44100
+        if self.audio_vae is not None and len(latent_shapes) > 1:
+            try:
+                audio_target_device = comfy.model_management.get_torch_device()
+                for p in self.audio_vae.first_stage_model.parameters():
+                    audio_restore_device = p.device
+                    break
+                self.audio_vae.first_stage_model.to(audio_target_device)
+                audio_first_stage = self.audio_vae.first_stage_model
+                audio_sample_rate = getattr(
+                    self.audio_vae, "audio_sample_rate_output",
+                    getattr(self.audio_vae, "audio_sample_rate", 44100),
+                )
+            except Exception as e:
+                logging.warning(f"[KJ PreviewOverride] audio VAE setup failed: {e}")
+                audio_first_stage = None
 
         previewer = _get_core_previewer(model_patcher.load_device, model_patcher.model.latent_format)
         # Latent2RGB fallback — used when the active previewer returns a non-PIL result
@@ -553,10 +620,24 @@ class _PreviewOverrideWrapper:
                         sigma_val = sigmas_list[step] if 0 <= step < len(sigmas_list) else None
                         sent_step = step + 1
 
+                        # Decode audio inline from the raw packed x0; WAV/base64 packing is
+                        # deferred to the async encoder below, like the image path.
+                        audio_wave_cpu = None
+                        if audio_first_stage is not None:
+                            try:
+                                unpacked = comfy.utils.unpack_latents(x0, latent_shapes)
+                                if len(unpacked) > 1:
+                                    audio_wave_cpu = _decode_audio_waveform(
+                                        audio_first_stage, unpacked[1], audio_target_device,
+                                    )
+                            except Exception as e:
+                                logging.warning(f"[KJ PreviewOverride] audio extract failed: {e}")
+
                         def _encode_and_send(
                             pil_frames=pil_frames, x0_cpu_now=x0_cpu_now, prev_x0_cpu=prev_x0_cpu,
                             step_ms=step_ms, avg_step_ms=avg_step_ms, sigma_val=sigma_val,
                             sent_step=sent_step, total_steps_=total_steps_,
+                            audio_wave_cpu=audio_wave_cpu, audio_sample_rate=audio_sample_rate,
                         ):
                             if len(pil_frames) > 1:
                                 # NVENC ~8x faster + ~5x smaller than PIL WebP when available.
@@ -586,24 +667,29 @@ class _PreviewOverrideWrapper:
                                 diff = x0_cpu_now - prev_x0_cpu
                                 delta_v = (diff.norm() / max(1, diff.numel()) ** 0.5).item()
 
+                            payload = {
+                                "node_id": node_id,
+                                "image": b64,
+                                "mime": mime,
+                                "w": w_,
+                                "h": h_,
+                                "step": sent_step,
+                                "total": total_steps_,
+                                "sigma": sigma_val,
+                                "sigmas": None,
+                                "delta": delta_v,
+                                "step_ms": step_ms,
+                                "avg_step_ms": avg_step_ms,
+                                "fps": anim_fps if mime in ("video/mp4", "image/webp") else None,
+                            }
+                            audio_b64 = _encode_wav_b64(audio_wave_cpu, audio_sample_rate)
+                            if audio_b64 is not None:
+                                payload["audio"] = audio_b64
+                                payload["audio_sample_rate"] = int(audio_sample_rate)
+                                payload["audio_mime"] = "audio/wav"
+
                             PromptServer.instance.send_sync(
-                                "kj_preview_override",
-                                {
-                                    "node_id": node_id,
-                                    "image": b64,
-                                    "mime": mime,
-                                    "w": w_,
-                                    "h": h_,
-                                    "step": sent_step,
-                                    "total": total_steps_,
-                                    "sigma": sigma_val,
-                                    "sigmas": None,
-                                    "delta": delta_v,
-                                    "step_ms": step_ms,
-                                    "avg_step_ms": avg_step_ms,
-                                    "fps": anim_fps if mime in ("video/mp4", "image/webp") else None,
-                                },
-                                PromptServer.instance.client_id,
+                                "kj_preview_override", payload, PromptServer.instance.client_id,
                             )
 
                         encoder.submit(_encode_and_send)
@@ -637,6 +723,11 @@ class _PreviewOverrideWrapper:
             if vae_restore_device is not None and self.vae is not None:
                 try:
                     self.vae.first_stage_model.to(vae_restore_device)
+                except Exception:
+                    pass
+            if audio_restore_device is not None and self.audio_vae is not None:
+                try:
+                    self.audio_vae.first_stage_model.to(audio_restore_device)
                 except Exception:
                     pass
 
@@ -702,6 +793,12 @@ class ModelPreviewOverrideKJ(io.ComfyNode):
                             "(VAE pinned to GPU). Any other LTX VAE = full-quality decode via "
                             "vae.decode() — MUCH slower per step.",
                 ),
+                io.Vae.Input(
+                    "audio_vae",
+                    optional=True,
+                    tooltip="Optional LTXAV audio VAE. When connected, the audio is decoded and "
+                            "previewed in sync with the video during sampling.",
+                ),
             ],
             outputs=[io.Model.Output(tooltip="Model with preview override attached.")],
             hidden=[io.Hidden.unique_id],
@@ -709,14 +806,14 @@ class ModelPreviewOverrideKJ(io.ComfyNode):
         )
 
     @classmethod
-    def execute(cls, model, max_resolution, jpeg_quality, suppress_default_preview, preview_frames, preview_fps, vae=None) -> io.NodeOutput:
+    def execute(cls, model, max_resolution, jpeg_quality, suppress_default_preview, preview_frames, preview_fps, vae=None, audio_vae=None) -> io.NodeOutput:
         m = model.clone()
         m.add_wrapper_with_key(
             comfy.patcher_extension.WrappersMP.OUTER_SAMPLE,
             "kj_preview_override",
             _PreviewOverrideWrapper(
                 max_resolution, cls.hidden.unique_id, jpeg_quality, suppress_default_preview,
-                preview_frames, preview_fps, vae,
+                preview_frames, preview_fps, vae, audio_vae,
             ),
         )
         return io.NodeOutput(m)

--- a/web/js/preview_override/preview_override.js
+++ b/web/js/preview_override/preview_override.js
@@ -320,6 +320,29 @@ app.registerExtension({
             const videoB = mkVideo();
             let visibleVideo = videoA;
             let pendingVideo = videoB;
+            // Hidden audio sources (LTXAV). Double-buffered like the video for gapless step
+            // swaps; both ride the same playback clock as the visual preview.
+            function mkAudio() {
+                const a = el("audio", null, imageArea);
+                a.style.display = "none";
+                a.preload = "auto";
+                a.loop = true;
+                a.muted = true;  // unmuted only while hovering the preview or step plot
+                return a;
+            }
+            const audioA = mkAudio();
+            const audioB = mkAudio();
+            let visibleAudio = audioA;
+            let pendingAudio = audioB;
+            // Keep audio quiet during normal graph work; it "opens up" only when the cursor is
+            // over the preview frame or the σ/Δ plot. Starting muted also guarantees autoplay.
+            let audioHoverImage = false;
+            let audioHoverPlot = false;
+            function refreshAudioMute() {
+                const muted = !(audioHoverImage || audioHoverPlot);
+                audioA.muted = muted;
+                audioB.muted = muted;
+            }
             const placeholder = el("div", "kj-pov-placeholder", imageArea);
             placeholder.textContent = "waiting for sample…";
             // Playback scrub bar — hidden until animated content is loaded.
@@ -444,8 +467,11 @@ app.registerExtension({
             const stepBlobUrls = [];
             const stepVideoFrames = [];  // WebP path: per-step VideoFrame[]
             const stepMp4Urls = [];      // MP4 path: per-step blob URL
+            const stepAudioUrls = [];    // LTXAV: per-step WAV blob URL
             let liveBlobUrl = null;
             let liveMp4Url = null;
+            let liveAudioUrl = null;
+            let currentAudioUrl = null;
             // Global timer never resets between steps — scrub continues at the equivalent elapsed.
             let playbackStartMs = null;
             let videoRafId = null;
@@ -526,6 +552,43 @@ app.registerExtension({
             // MP4 encode-time fps; scales videoEl.playbackRate for live preview_fps retime.
             let bakedFps = null;
 
+            function audioActive() {
+                return currentAudioUrl != null && Number.isFinite(visibleAudio.duration) && visibleAudio.duration > 0;
+            }
+            // Mirror showMp4: load into the pending element, seek to the master clock, play,
+            // then swap — keeps audio gapless across per-step buffer replacements.
+            function showAudio(url) {
+                if (url === currentAudioUrl) return;
+                currentAudioUrl = url;
+                if (playbackStartMs == null) playbackStartMs = performance.now();
+                const target = pendingAudio;
+                target.src = url;
+                const promote = () => {
+                    if (currentAudioUrl !== url || target !== pendingAudio) return;
+                    try {
+                        const dur = target.duration;
+                        if (Number.isFinite(dur) && dur > 0) target.currentTime = (elapsedMs() / 1000) % dur;
+                    } catch {}
+                    if (!isPaused) target.play().catch(() => {});
+                    const prev = visibleAudio;
+                    prev.pause();
+                    visibleAudio = target;
+                    pendingAudio = prev;
+                };
+                const onLoaded = () => {
+                    target.removeEventListener("loadeddata", onLoaded);
+                    promote();
+                };
+                if (target.readyState >= 2) onLoaded();
+                else target.addEventListener("loadeddata", onLoaded, { once: true });
+            }
+            function stopAudio() {
+                currentAudioUrl = null;
+                for (const a of [audioA, audioB]) {
+                    try { a.pause(); a.removeAttribute("src"); a.load(); } catch {}
+                }
+            }
+
             function mp4Active() {
                 return currentMp4Url != null && Number.isFinite(visibleVideo.duration) && visibleVideo.duration > 0;
             }
@@ -533,6 +596,8 @@ app.registerExtension({
                 if (mp4Active()) return visibleVideo.duration * 1000;
                 const v = stepVideoFrames[activeStepIdx()];
                 if (v && v.frames.length > 1) return v.frames.length * (1000 / currentFps());
+                // Audio drives the scrub timeline when the video preview is a still frame.
+                if (audioActive()) return visibleAudio.duration * 1000;
                 return 0;
             }
             function getProgress() {
@@ -552,12 +617,19 @@ app.registerExtension({
                 if (mp4Active()) {
                     visibleVideo.currentTime = pos * visibleVideo.duration;
                 }
+                if (audioActive()) {
+                    try { visibleAudio.currentTime = ((pos * dur) / 1000) % visibleAudio.duration; } catch {}
+                }
             }
             function togglePause() {
                 const willPause = !isPaused;
                 if (mp4Active()) {
                     if (willPause) visibleVideo.pause();
                     else visibleVideo.play().catch(() => {});
+                }
+                if (audioActive()) {
+                    if (willPause) visibleAudio.pause();
+                    else visibleAudio.play().catch(() => {});
                 }
                 if (willPause) {
                     pauseAtMs = performance.now();
@@ -582,6 +654,19 @@ app.registerExtension({
                     const rate = currentFps() / bakedFps;
                     if (Math.abs(visibleVideo.playbackRate - rate) > 0.001) {
                         visibleVideo.playbackRate = rate;
+                    }
+                }
+                // Keep audio aligned to the master clock. Native playback advances on its own,
+                // so we only re-seek on meaningful drift (after a step swap or a scrub).
+                if (audioActive()) {
+                    if (isPaused) {
+                        if (!visibleAudio.paused) visibleAudio.pause();
+                    } else {
+                        if (visibleAudio.paused) visibleAudio.play().catch(() => {});
+                        const want = (elapsedMs() / 1000) % visibleAudio.duration;
+                        if (Math.abs(visibleAudio.currentTime - want) > 0.25) {
+                            try { visibleAudio.currentTime = want; } catch {}
+                        }
                     }
                 }
             }
@@ -744,6 +829,15 @@ app.registerExtension({
                     }
                 }
             }
+            function setStepAudio(stepIdx, blob) {
+                const url = URL.createObjectURL(blob);
+                if (stepAudioUrls[stepIdx]) {
+                    try { URL.revokeObjectURL(stepAudioUrls[stepIdx]); } catch {}
+                }
+                stepAudioUrls[stepIdx] = url;
+                liveAudioUrl = url;
+                if (hoverStep == null && lockedStep == null) showAudio(url);
+            }
             function resetFrames() {
                 for (const u of stepBlobUrls) {
                     if (u) try { URL.revokeObjectURL(u); } catch {}
@@ -759,6 +853,12 @@ app.registerExtension({
                 stepMp4Urls.length = 0;
                 liveMp4Url = null;
                 hideMp4();
+                for (const u of stepAudioUrls) {
+                    if (u) try { URL.revokeObjectURL(u); } catch {}
+                }
+                stepAudioUrls.length = 0;
+                liveAudioUrl = null;
+                stopAudio();
                 playbackStartMs = null;
                 bakedFps = null;
                 isPaused = false;
@@ -814,6 +914,12 @@ app.registerExtension({
                     hideMp4();
                     showLiveFrame(liveBlobUrl);
                 }
+                // Audio follows the same locked > hover > live priority as the visual.
+                if (displayStep != null && stepAudioUrls[displayStep]) {
+                    showAudio(stepAudioUrls[displayStep]);
+                } else if (liveAudioUrl) {
+                    showAudio(liveAudioUrl);
+                }
             }
 
             sdRow.canvas.addEventListener("mousemove", (ev) => {
@@ -834,6 +940,12 @@ app.registerExtension({
                     redrawSd();
                 }
             });
+
+            // Unmute audio only while hovering the preview frame or the σ/Δ step plot.
+            imageArea.addEventListener("mouseenter", () => { audioHoverImage = true; refreshAudioMute(); });
+            imageArea.addEventListener("mouseleave", () => { audioHoverImage = false; refreshAudioMute(); });
+            sdRow.canvas.addEventListener("mouseenter", () => { audioHoverPlot = true; refreshAudioMute(); });
+            sdRow.canvas.addEventListener("mouseleave", () => { audioHoverPlot = false; refreshAudioMute(); });
 
             // Click toggles a lock at the hover position so the preview survives mouseleave.
             sdRow.canvas.addEventListener("mousedown", (ev) => { ev.stopPropagation(); });
@@ -907,6 +1019,11 @@ app.registerExtension({
                         const mime = typeof data.mime === "string" ? data.mime : "image/jpeg";
                         if (typeof data.fps === "number" && data.fps > 0) bakedFps = data.fps;
                         setStepBlob(data.step, b64ToBlob(data.image, mime));
+                    }
+                    // LTXAV audio for this step — rides the same playback clock as the visual.
+                    if (typeof data.audio === "string") {
+                        const amime = typeof data.audio_mime === "string" ? data.audio_mime : "audio/wav";
+                        setStepAudio(data.step, b64ToBlob(data.audio, amime));
                     }
 
                     totalSteps = data.total || totalSteps;


### PR DESCRIPTION
Adds an optional `audio_vae` input to Model Preview Override. On LTXAV (audio+video) models the separated audio latent is decoded each sampling step and played back in sync with the video preview, so the audio sharpens alongside the video as denoising proceeds.

The `<audio>` element rides the same playback clock and double-buffer/seek pattern as the existing MP4 path (`showMp4`), so pausing, scrubbing, and per-step lock work for audio too. The audio VAE, which is relatively small, runs directly on `first_stage_model`, pinned to GPU for the run (the same device-handling the node already uses for the TAEHV previewer),

No behavior change unless `audio_vae` is wired and the audio is muted unless hovering over the relevant UI elements.
