### PR TITLE
Fix: SetNode rename-migration permanently armed when previousName drifts

### DIFF
--- a/web/js/setgetnodes.js
+++ b/web/js/setgetnodes.js
@@ -771,6 +771,14 @@ app.registerExtension({
 						getter.setName(this.widgets[0].value);
 					});
 				}
+				// Reconcile previousName so the migration above cannot fire again on a
+				// stale name. Without this, a SetNode whose previousName drifts from its
+				// current widget value (paste, partial load, or any path that mutates the
+				// widget without going through the text-widget callback) permanently
+				// hijacks any future GetNode named the old value.
+				if (this.widgets[0].value) {
+					this.properties.previousName = this.widgets[0].value;
+				}
 				app.canvas?.setDirty(true, true);
 			}
 


### PR DESCRIPTION
## Problem

`SetNode.update()` (web/js/setgetnodes.js) performs a rename-migration: when `widgets[0].value` differs from `properties.previousName`, it walks the graph and renames every GetNode currently bound to `previousName` so they follow the rename. This is the correct behavior when the user types a new name into the widget.

However, the invariant `previousName === widgets[0].value` after migration is only enforced by **two** call sites — the text-widget callback (constructor) and `onConnectionsChange`'s input-connect branch. Any path that mutates the widget value without going through those callbacks leaves `previousName` pointing at the old name forever:

- **Paste with name collision.** `onConfigure` calls `validateName(graph, true)` which appends `_N` to avoid duplicates, but doesn't update `previousName`.
- **Saved JSON with drifted state.** Once `previousName` has drifted, every reload preserves the drift; `update()` doesn't normalize it.
- Any future code path that touches `widgets[0].value` directly.

Once drifted, every subsequent `update()` call hijacks any GetNode the user creates with the stale name — silently rebinding it to the SetNode's current name.

## Real-world impact

A multi-chunk WAN Animate workflow had a SetNode originally named `chunk_length`, later renamed to `temporal_overlap_frames`. Its `previousName` retained `chunk_length` in the saved JSON. On every load, the SetNode's `update()` swept every GetNode bound to `chunk_length` into `temporal_overlap_frames`, silently breaking five chunk-length wires across the workflow. Each `WanAnimateToVideo.length` was being fed the overlap window (9 frames) instead of the computed per-chunk length, producing nonsensical output (9, 1, 8, 4, 8 frames across 5 chunks). The user could rebind the GetNodes by hand, but the next Submit re-triggered `update()` and the migration stole them back. The workflow was unfixable without editing JSON.

Verified by patching `previousName` in the saved JSON to match the current widget value: workflow loads and runs correctly with the expected per-chunk frame counts.

## Fix

At the end of `update()`, reconcile `properties.previousName = widgets[0].value`. The migration becomes idempotent — once consumed, it cannot re-fire on the same state.

Legitimate rename behavior is preserved: the next user-driven widget change still has the prior `previousName` to migrate from, because the existing widget callback updates `previousName` *after* `update()` returns (so the order is: capture old → migrate → reconcile, then on next edit: old is reconciled-to-previous, migrate again).

The change is 8 lines in one function.

## Risk

Low. The added assignment only fires when `widgets[0].value` is truthy, matching the guard on the migration block immediately above it. No legitimate path relies on `previousName` retaining a value other than the current widget value once `update()` has run.