### PR TITLE
Fix LTXVAudioVideoMask negative mask padding

### DIFF
--- a/nodes/ltxv_nodes.py
+++ b/nodes/ltxv_nodes.py
@@ -262,17 +262,23 @@ class LTXVAudioVideoMask(io.ComfyNode):
                 video_mask = video_latent["noise_mask"].clone()
                 # Adjust mask size based on mode
                 if max_length == "pad" and video_samples.shape[2] > video_latent["samples"].shape[2]:
-                    # Pad the mask if we padded the samples
-                    mask_padding = torch.zeros(
-                        video_mask.shape[0],
-                        video_mask.shape[1],
-                        video_samples.shape[2] - video_mask.shape[2],
-                        video_mask.shape[3],
-                        video_mask.shape[4],
-                        dtype=video_mask.dtype,
-                        device=video_mask.device
-                    )
-                    video_mask = torch.cat([video_mask, mask_padding], dim=2)
+                    extra = video_samples.shape[2] - video_mask.shape[2]
+                    if extra > 0:
+                        # Pad the mask if we padded the samples
+                        mask_padding = torch.zeros(
+                            video_mask.shape[0],
+                            video_mask.shape[1],
+                            extra,
+                            video_mask.shape[3],
+                            video_mask.shape[4],
+                            dtype=video_mask.dtype,
+                            device=video_mask.device
+                        )
+                        video_mask = torch.cat([video_mask, mask_padding], dim=2)
+                    else:
+                        # Existing mask already covers the padded samples;
+                        # trim it to match instead of padding by a negative amount.
+                        video_mask = video_mask[:, :, :video_samples.shape[2]]
                 elif max_length == "truncate":
                     # Truncate the mask to match truncated samples
                     video_mask = video_mask[:, :, :video_samples.shape[2]]
@@ -322,16 +328,22 @@ class LTXVAudioVideoMask(io.ComfyNode):
                 audio_mask = audio_latent["noise_mask"].clone()
                 # Adjust mask size based on mode
                 if max_length == "pad" and audio_samples.shape[2] > audio_latent["samples"].shape[2]:
-                    # Pad the mask if we padded the samples
-                    mask_padding = torch.zeros(
-                        audio_mask.shape[0],
-                        audio_mask.shape[1],
-                        audio_samples.shape[2] - audio_mask.shape[2],
-                        audio_mask.shape[3],
-                        dtype=audio_mask.dtype,
-                        device=audio_mask.device
-                    )
-                    audio_mask = torch.cat([audio_mask, mask_padding], dim=2)
+                    extra = audio_samples.shape[2] - audio_mask.shape[2]
+                    if extra > 0:
+                        # Pad the mask if we padded the samples
+                        mask_padding = torch.zeros(
+                            audio_mask.shape[0],
+                            audio_mask.shape[1],
+                            extra,
+                            audio_mask.shape[3],
+                            dtype=audio_mask.dtype,
+                            device=audio_mask.device
+                        )
+                        audio_mask = torch.cat([audio_mask, mask_padding], dim=2)
+                    else:
+                        # Existing mask already covers the padded samples;
+                        # trim it to match instead of padding by a negative amount.
+                        audio_mask = audio_mask[:, :, :audio_samples.shape[2]]
                 elif max_length == "truncate":
                     # Truncate the mask to match truncated samples
                     audio_mask = audio_mask[:, :, :audio_samples.shape[2]]


### PR DESCRIPTION
Fixes #615.

`LTXVAudioVideoMask` crashes with `Trying to create tensor with negative dimension` when an existing `noise_mask` has more frames than the padded samples.

In the existing-mask `pad` branch the guard checks that the samples grew (`samples.shape[2] > original_samples.shape[2]`), but the padding amount is `samples.shape[2] - mask.shape[2]`. When the incoming `noise_mask` already has more frames than the padded samples, that subtraction is negative and `torch.zeros(..., negative, ...)` raises. The reporter's `[1, 1, -32, 640]` is the audio branch (4D); the video branch (5D) has the same defect.

Fix: compute `extra = samples - mask` and pad only when it is positive, otherwise trim the mask to the sample length (matching the existing `truncate` behaviour). Applied to both branches.

Verified with a CPU repro of the exact shape arithmetic (samples padded to fewer frames than the existing mask):

```
before: RuntimeError: zeros: Dimension size must be non-negative
after:  samples=(1, 128, 6, 640) mask=(1, 1, 6, 640)  (mask frames == samples frames)
```