### PR TITLE
Allow input bounding boxes in Ideogram4 prompt builder node

### DIFF
--- a/nodes/ideogram4_nodes.py
+++ b/nodes/ideogram4_nodes.py
@@ -330,7 +330,7 @@ the canvas aspect ratio.""",
         # ui: send the resolved width/height so the editor canvas can follow connected
         # inputs; import_json (if wired) loads into the editor (output reflects editor only).
         ui = {"dims": [width, height]}
-        if boxes_seeded:                                    # push the seeded regions into the editor
+        if boxes_seeded:
             ui["boxes"] = [json.dumps(boxes)]
         if import_json and import_json.strip():
             try:

--- a/nodes/ideogram4_nodes.py
+++ b/nodes/ideogram4_nodes.py
@@ -223,15 +223,15 @@ the canvas aspect ratio.""",
                 io.String.Input("import_json", default="", optional=True, force_input=True,
                                 tooltip="Optional: a full caption JSON. When connected, it loads into the "
                                         "editor on run; the output always reflects the editor, never the raw input."),
-                io.BoundingBox.Input("bboxes", optional=True,
-                                     tooltip="Optional pixel-space boxes ({x, y, width, height}) used to seed the "
-                                             "editor's regions when it has none. Ignored once regions exist."),
                 io.String.Input("style_palette_data", default="", socketless=True, advanced=True,
                                 tooltip="Serialized style color palette from the editor (managed by the node UI)."),
                 io.String.Input("elements_data", default="", socketless=True, advanced=True,
                                 tooltip="Serialized regions from the editor (managed by the node UI)."),
                 io.Int.Input("bg_brightness", default=25, min=0, max=100, socketless=True, advanced=True,
                              tooltip="Background image brightness % (managed by the node UI slider)."),
+                io.BoundingBox.Input("bboxes", optional=True, force_input=True,
+                                     tooltip="Optional pixel-space boxes ({x, y, width, height}) used to seed the "
+                                             "editor's regions when it has none. Ignored once regions exist."),
             ],
             outputs=[
                 io.String.Output(display_name="prompt"),

--- a/nodes/ideogram4_nodes.py
+++ b/nodes/ideogram4_nodes.py
@@ -250,7 +250,12 @@ the canvas aspect ratio.""",
         boxes = _parse_json_list(elements_data)
         boxes_seeded = False
         if not boxes and bboxes:
-            frame = bboxes[0] if isinstance(bboxes[0], (list, tuple)) else bboxes  # accept per-frame nesting or flat
+            if isinstance(bboxes, dict):                     # a single BoundingBox is a bare {x,y,width,height} dict
+                frame = [bboxes]
+            elif bboxes and isinstance(bboxes[0], (list, tuple)):
+                frame = bboxes[0]                            # per-frame nesting: [[box, ...], ...]
+            else:
+                frame = bboxes                               # flat list of boxes
             for bb in frame:
                 if not isinstance(bb, dict):
                     continue

--- a/nodes/ideogram4_nodes.py
+++ b/nodes/ideogram4_nodes.py
@@ -223,6 +223,9 @@ the canvas aspect ratio.""",
                 io.String.Input("import_json", default="", optional=True, force_input=True,
                                 tooltip="Optional: a full caption JSON. When connected, it loads into the "
                                         "editor on run; the output always reflects the editor, never the raw input."),
+                io.BoundingBox.Input("bboxes", optional=True,
+                                     tooltip="Optional pixel-space boxes ({x, y, width, height}) used to seed the "
+                                             "editor's regions when it has none. Ignored once regions exist."),
                 io.String.Input("style_palette_data", default="", socketless=True, advanced=True,
                                 tooltip="Serialized style color palette from the editor (managed by the node UI)."),
                 io.String.Input("elements_data", default="", socketless=True, advanced=True,
@@ -242,8 +245,19 @@ the canvas aspect ratio.""",
     @classmethod
     def execute(cls, width, height, background, style,
                 high_level_description="", aesthetics="", lighting="", medium="",
-                style_palette_data="", elements_data="", import_json="", image=None, bg_brightness=25) -> io.NodeOutput:
+                style_palette_data="", elements_data="", import_json="", bboxes=None,
+                image=None, bg_brightness=25) -> io.NodeOutput:
         boxes = _parse_json_list(elements_data)
+        boxes_seeded = False
+        if not boxes and bboxes:
+            frame = bboxes[0] if isinstance(bboxes[0], (list, tuple)) else bboxes  # accept per-frame nesting or flat
+            for bb in frame:
+                if not isinstance(bb, dict):
+                    continue
+                boxes.append({"x": bb.get("x", 0) / width, "y": bb.get("y", 0) / height,
+                              "w": bb.get("width", 0) / width, "h": bb.get("height", 0) / height,
+                              "type": "obj", "text": "", "desc": "", "palette": []})
+            boxes_seeded = bool(boxes)
 
         caption = {}
         if high_level_description.strip():
@@ -316,6 +330,8 @@ the canvas aspect ratio.""",
         # ui: send the resolved width/height so the editor canvas can follow connected
         # inputs; import_json (if wired) loads into the editor (output reflects editor only).
         ui = {"dims": [width, height]}
+        if boxes_seeded:                                    # push the seeded regions into the editor
+            ui["boxes"] = [json.dumps(boxes)]
         if import_json and import_json.strip():
             try:
                 cap = json.loads(import_json)

--- a/web/js/ideogram4_prompt_builder.js
+++ b/web/js/ideogram4_prompt_builder.js
@@ -1006,6 +1006,16 @@ app.registerExtension({
       }
       chainCallback(node, "onExecuted", function (message) {
         if (message?.caption) applyImported(message.caption[0]);
+        // Seed regions from the bboxes input only when the editor is empty, so user-drawn/edited
+        // regions are never overwritten.
+        if (message?.boxes && !node._boxes.length) {
+          const seeded = JSON.parse(message.boxes[0]);
+          if (Array.isArray(seeded) && seeded.length) {
+            node._boxes = seeded.filter((b) => b && typeof b.x === "number" && typeof b.w === "number");
+            node._activeIdx = node._boxes.length ? 0 : -1;
+            commit(); fitNode();
+          }
+        }
         // Reflect resolved width/height (e.g. from connected inputs) in the canvas aspect.
         // A connected background image governs the aspect itself, so skip then.
         if (message?.dims && !node._bgImg) {


### PR DESCRIPTION
Adds an optional bboxes input to the Ideogram 4 prompt builder - input bounding boxes are only used if no bounding boxes have been setup in the node, at which point they are used to initialize the node's bounding boxes (as shown in UI).

This is useful to e.g. initialize a set of boxes from the output of the SAM3 Detect node, allowing for quick blocking out of complex poses:

<img width="1336" height="422" alt="image" src="https://github.com/user-attachments/assets/c6561e50-6a11-4e77-a8b5-40be127ea295" />
