### PR TITLE
Fix TritonVAE device mismatch in int8 conv path during lowvram/partial VAE loads

### DIFF
--- a/nodes/triton_vae.py
+++ b/nodes/triton_vae.py
@@ -562,13 +562,20 @@ class Int8CausalConv3d(CausalConv3d):
                                                    BLOCK=4096, num_warps=8)
 
         C_out = self.out_channels
-        scale_vec = self.int8_sw * amax.float()
+        int8_qw = self.int8_qw
+        int8_sw = self.int8_sw
+        if int8_sw.device != x.device:  # lowvram partial load keeps custom buffers off-device
+            int8_qw = int8_qw.to(x.device)
+            int8_sw = int8_sw.to(x.device)
+        scale_vec = int8_sw * amax.float()
         bias = self.bias
+        if bias is not None and bias.device != x.device:  # lowvram partial load keeps bias param off-device
+            bias = bias.to(x.device)
         T_out = T_in - 2
         M = T_out * hw
         out = torch.empty(M, C_out, device=x.device, dtype=x.dtype)
         grid = (triton.cdiv(M, 128), triton.cdiv(C_out, 64))
-        _conv3d_s8[grid](qx, self.int8_qw, out, scale_vec,
+        _conv3d_s8[grid](qx, int8_qw, out, scale_vec,
                          bias.float() if bias is not None else scale_vec,
                          H, W, C_pad, C_out, 3 * C_pad, M,
                          BLOCK_M=128, BLOCK_N=64, BLOCK_K=64,
@@ -606,12 +613,19 @@ class Int8Conv2d(comfy.ops.disable_weight_init.Conv2d):
                                                    BLOCK=4096, num_warps=8)
 
         C_out = self.out_channels
-        scale_vec = self.int8_sw * amax.float()
+        int8_qw = self.int8_qw
+        int8_sw = self.int8_sw
+        if int8_sw.device != x.device:  # lowvram partial load keeps custom buffers off-device
+            int8_qw = int8_qw.to(x.device)
+            int8_sw = int8_sw.to(x.device)
+        scale_vec = int8_sw * amax.float()
         bias = self.bias
+        if bias is not None and bias.device != x.device:  # lowvram partial load keeps bias param off-device
+            bias = bias.to(x.device)
         M = B * H * W
         out = torch.empty(M, C_out, device=x.device, dtype=x.dtype)
         grid = (triton.cdiv(M, 128), triton.cdiv(C_out, 64))
-        _conv2d_s8[grid](qx, self.int8_qw, out, scale_vec,
+        _conv2d_s8[grid](qx, int8_qw, out, scale_vec,
                          bias.float() if bias is not None else scale_vec,
                          H, W, C_pad, C_out, 3 * C_pad, M,
                          BLOCK_M=128, BLOCK_N=64, BLOCK_K=64,
@@ -647,13 +661,20 @@ class Int8InnerConv3d(comfy.ops.disable_weight_init.Conv3d):
                                                    BLOCK=4096, num_warps=8)
 
         C_out = self.out_channels
-        scale_vec = self.int8_sw * amax.float()
+        int8_qw = self.int8_qw
+        int8_sw = self.int8_sw
+        if int8_sw.device != x.device:  # lowvram partial load keeps custom buffers off-device
+            int8_qw = int8_qw.to(x.device)
+            int8_sw = int8_sw.to(x.device)
+        scale_vec = int8_sw * amax.float()
         bias = self.bias
+        if bias is not None and bias.device != x.device:  # lowvram partial load keeps bias param off-device
+            bias = bias.to(x.device)
         T_out = T_in - 2
         M = T_out * H * W
         out = torch.empty(M, C_out, device=x.device, dtype=x.dtype)
         grid = (triton.cdiv(M, 128), triton.cdiv(C_out, 64))
-        _conv3d_s8[grid](qx, self.int8_qw, out, scale_vec,
+        _conv3d_s8[grid](qx, int8_qw, out, scale_vec,
                          bias.float() if bias is not None else scale_vec,
                          H, W, C_pad, C_out, 3 * C_pad, M,
                          BLOCK_M=128, BLOCK_N=64, BLOCK_K=64,


### PR DESCRIPTION
## Problem

`Int8CausalConv3d`, `Int8Conv2d`, and `Int8InnerConv3d` in `nodes/triton_vae.py` throw a device-mismatch error (and, with `--fast`/certain triton versions, a `ValueError: Pointer argument cannot be accessed from Triton`) when the VAE falls back to a partial/lowvram load instead of a full load.

Repro: run VAEDecode (or an upscale-pass decode) after enough VRAM pressure that the VideoVAE gets staged as `loaded partially; 0.00 MB usable, ..., lowvram patches: 0` instead of a full load. Both `RuntimeError: Expected all tensors to be on the same device` and, once the first issue is worked around, `ValueError: Pointer argument cannot be accessed from Triton (cpu tensor?)` are reproducible this way.

## Root cause

ComfyUI's dynamic VRAM / lowvram loader only device-casts real model parameters/buffers routed through `comfy.ops` (i.e. `weight`). Two things in these int8 conv classes fall outside that path:

1. `int8_qw` / `int8_sw` — registered via `register_buffer(..., persistent=False)`, which is correct for `state_dict` behavior but doesn't put them in ComfyUI's lowvram casting sweep.
2. `self.bias` — assigned directly from the original conv's `Parameter` (`self.bias = orig.bias`), sharing the same tensor object rather than being reinitialized through the patcher, so it isn't touched either.

Under a full load both land on `x.device` incidentally. Under a partial/lowvram load, both can remain on `cpu` while the activation tensor `x` is on `cuda`, causing the failures above at the `scale_vec = self.int8_sw * amax.float()` and `bias.float()` call sites.

This mirrors an existing guard already present in `FusedRMSSiLU`/`FusedGNSiLU` in the same file (`if gamma.device != x.device: gamma = gamma.to(x.device)`) — this PR just extends the same pattern to the int8 conv classes, which didn't have it.

## Fix

In `Int8CausalConv3d._int8_forward`, `Int8Conv2d.forward`, and `Int8InnerConv3d.forward`: before use, check `int8_sw`/`int8_qw` and `bias` against `x.device` and move them if needed, same as the existing fused-norm classes already do for `gamma`/`weight`/`bias`.

```python
int8_qw = self.int8_qw
int8_sw = self.int8_sw
if int8_sw.device != x.device:  # lowvram partial load keeps custom buffers off-device
    int8_qw = int8_qw.to(x.device)
    int8_sw = int8_sw.to(x.device)
scale_vec = int8_sw * amax.float()
bias = self.bias
if bias is not None and bias.device != x.device:  # lowvram partial load keeps bias param off-device
    bias = bias.to(x.device)
```

(with `int8_qw`/`bias` used in place of `self.int8_qw`/`self.bias` in the subsequent kernel call)

## Testing

Reproduced on LTX2.3 decode (`Int8CausalConv3d` path) with dynamic VRAM enabled, forcing a partial VAE load via VRAM pressure from a prior sampling stage. Confirmed the error no longer occurs after the fix, decode completes normally. `Int8Conv2d` and `Int8InnerConv3d` weren't independently reproduced but have the identical pattern, so the same fix is applied preemptively.