### PR TITLE
added OUTPUT_IS_LIST to StringToFloatList

### DIFF
--- a/nodes/nodes.py
+++ b/nodes/nodes.py
@@ -1129,6 +1129,7 @@ class StringToFloatList:
                 }
     RETURN_TYPES = ("FLOAT",)
     RETURN_NAMES = ("FLOAT",)
+    OUTPUT_IS_LIST = (True,)    
     CATEGORY = "KJNodes/misc"
     FUNCTION = "createlist"
 


### PR DESCRIPTION
Addresses #685 

Sorry, I should have looked into the Comfyroll code before opening an issue. The code was really readable, the only difference was this `OUTPUT_IS_LIST` class variable. Setting it did the trick.