### PR TITLE
fix: only load kjweb_async marked/purify when native renderer is absent

### DIFF
--- a/web/js/help_popup.js
+++ b/web/js/help_popup.js
@@ -38,12 +38,18 @@ export const loadScript = (
   })
 }
 
-loadScript('kjweb_async/marked.min.js').catch((e) => {
-  console.error(e)
-})
-loadScript('kjweb_async/purify.min.js').catch((e) => {
-  console.error(e)
-})
+// Only load the bundled marked/DOMPurify fallback when the frontend lacks the
+// native markdown renderer (added in ComfyUI_frontend PR #10700). On newer
+// frontends renderMarkdownToHtml is used instead, so loading these is dead
+// weight and, when the pack root isn't served, produces 404s (e.g. on Cloud).
+if (!app.extensionManager?.renderMarkdownToHtml) {
+  loadScript('kjweb_async/marked.min.js').catch((e) => {
+    console.error(e)
+  })
+  loadScript('kjweb_async/purify.min.js').catch((e) => {
+    console.error(e)
+  })
+}
 
 const categories = ["KJNodes", "SUPIR", "VoiceCraft", "Marigold", "IC-Light", "WanVideoWrapper"];
 const nodeDescriptions = new Map();

--- a/web/js/help_popup.js
+++ b/web/js/help_popup.js
@@ -38,10 +38,7 @@ export const loadScript = (
   })
 }
 
-// Only load the bundled marked/DOMPurify fallback when the frontend lacks the
-// native markdown renderer (added in ComfyUI_frontend PR #10700). On newer
-// frontends renderMarkdownToHtml is used instead, so loading these is dead
-// weight and, when the pack root isn't served, produces 404s (e.g. on Cloud).
+// Only load the marked/DOMPurify fallback when the native renderer is absent.
 if (!app.extensionManager?.renderMarkdownToHtml) {
   loadScript('kjweb_async/marked.min.js').catch((e) => {
     console.error(e)


### PR DESCRIPTION
The help popup loads `marked.min.js` and `purify.min.js` as unconditional top-level side effects, but they're only used as a fallback when `app.extensionManager?.renderMarkdownToHtml` is unavailable. On frontends that have the native renderer, both scripts load but are never used.

This gates the loads behind the same check the render path already uses, so they only load when actually needed:

```js
if (!app.extensionManager?.renderMarkdownToHtml) {
  loadScript('kjweb_async/marked.min.js').catch((e) => { console.error(e) })
  loadScript('kjweb_async/purify.min.js').catch((e) => { console.error(e) })
}
```

No change on older frontends (fallback still loads).