### PR TITLE
Fix sageplus sm89 detection with sageattention >= 2.2

### DIFF
--- a/nodes/ltxv_nodes.py
+++ b/nodes/ltxv_nodes.py
@@ -1707,13 +1707,16 @@ except Exception:
     pass
 try:
     from sageattention.core import _qattn_sm89
-    cuda_version = get_cuda_version()
-    sageplus_sm89_available = hasattr(_qattn_sm89, 'qk_int8_sv_f8_accum_f16_fuse_v_scale_attn_inst_buf') and cuda_version >= (12, 8)
 except ImportError:
     try:
+        # sageattention >= 2.2 exposes the same kernels as sm89_compile instead
         from sageattention.core import sm89_compile as _qattn_sm89
     except ImportError:
         _qattn_sm89 = None
+# check whichever of the two imports above succeeded, not just the first one
+if _qattn_sm89 is not None:
+    cuda_version = get_cuda_version()
+    sageplus_sm89_available = hasattr(_qattn_sm89, 'qk_int8_sv_f8_accum_f16_fuse_v_scale_attn_inst_buf') and cuda_version >= (12, 8)
 try:
     from sageattention.core import _qattn_sm80
 except ImportError:


### PR DESCRIPTION
### Problem

On sm89 with sageattention >= 2.2, `sageplus_sm89_available` is always `False`, so the `fp32+fp16` branch is never taken.

sageattention >= 2.2 exposes the sm89 kernels as `sm89_compile` rather than `_qattn_sm89`, so the import at `ltxv_nodes.py:1709` raises `ImportError`. The `except` branch already handles that rename, but the two lines that set the flag sit inside the same `try` after the failing import, so they never run and it keeps its default of `False`.

### Fix

Move the check out of the `try` so it runs against whichever import succeeded. Probing the resolved object means installs that genuinely lack the kernel still evaluate to `False`, and on 2.1.x, where the first import succeeds, the check runs on the same object as before and the result is unchanged.

### Result

In my environment — ComfyUI's MiniMax H3 T2V template with the `MiniMax H3 Mem Eff Sage Attention Patch` node added — the patched path selects `qk_int8_sv_f8_accum_f16_fuse_v_scale_attn_inst_buf` and average generation time improves by about 5% (316.5 s to 300.4 s). 20 steps, fixed seed, no other acceleration nodes, warmup runs discarded. 

### Environment

```
OS:            Ubuntu 26.04 LTS (kernel 7.0.0-28-generic)
GPU:           NVIDIA GeForce RTX 4060 (sm89)
Python:        3.13.14
torch:         2.12.1+cu130
triton:        3.7.1
nvcc:          13.2.51
sageattention: 2.2.0 (built from source, thu-ml/SageAttention @ d1a57a5)
ComfyUI:       0.30.0
```