### PR TITLE
Handle sm121 (Blackwell GB10 / DGX Spark) in SageAttention dispatch

### DIFF
--- a/nodes/ltxv_nodes.py
+++ b/nodes/ltxv_nodes.py
@@ -1924,7 +1924,7 @@ def _sageattn_int8_fp8_nhd(qkv, dtype):
         o = torch.empty(q_int8.size(), dtype=dtype, device=q_int8.device)
         _qattn_sm90.qk_int8_sv_f8_accum_f32_fuse_v_scale_attn_inst_buf(q_int8, k_int8, v_fp8, o, q_scale, k_scale, v_scale, _tensor_layout, _is_caual, _qk_quant_gran, sm_scale, _return_lse)
         del v_fp8, v_scale
-    elif _cuda_archs[0] == "sm120":
+    elif _cuda_archs[0] in {"sm120", "sm121"}:
         if not sageplus_sm89_available:
             pv_accum_dtype = "fp32"
         else:


### PR DESCRIPTION
### What

Adds `sm121` to the arch dispatch in `_sageattn_int8_fp8_nhd()` (`nodes/ltxv_nodes.py`), routing it through the existing `sm120` Blackwell path.

Closes #719 .

### Why

The DGX Spark's GB10 GPU reports compute capability 12.1, so `sageattention.core.get_cuda_arch_versions()` returns `['sm121']`. The dispatch chain had no `sm121` case, so it fell through every branch to the unconditional `del q_int8, ...` at the end of the function and raised:

```
UnboundLocalError: cannot access local variable 'q_int8' where it is not associated with a value
```

This hit every SageAttention patch node (MiniMax H3, WanVideo, LTX2).

`sm121` (GB10) is Blackwell — same ISA family as the `sm120` (consumer Blackwell) branch — and that branch's kernels (`per_warp_int8_cuda`, `per_channel_fp8`, `_qattn_sm89`) are the correct ones for it.

### Change

```diff
-    elif _cuda_archs[0] == "sm120":
+    elif _cuda_archs[0] in {"sm120", "sm121"}:
```

### Safety / scope

- **Purely additive.** Only `sm121` GPUs change behavior; every other arch (sm75/80/86/89/90/120) takes the identical path as before, so this cannot regress existing users.
- Matches the existing house style (the `sm80`/`sm86` branch already uses a set literal).
- Deliberately kept as an explicit `{"sm120", "sm121"}` rather than a broad `startswith("sm12")`, to avoid presuming unknown future archs belong on this path.

### Testing

Verified on a DGX Spark (NVIDIA GB10, CC 12.1, aarch64, CUDA 13.0, SageAttention 2.2.0 built from source). The MiniMax H3 SageAttention patch node now runs to completion and produces correct output; previously it crashed immediately with the `UnboundLocalError` above.