### PR TITLE
fix: skip PatchTritonVAE registration when triton is not installed

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -378,13 +378,18 @@ try:
 except Exception as e:
     logging.warning(f"KJNodes: MiniMax nodes could not be imported. MiniMax nodes will be unavailable. Error: {e}", exc_info=True)
 
-try:
-    from .nodes.triton_vae import PatchTritonVAE
-    NODE_CONFIG.update({
-        "PatchTritonVAE": {"class": PatchTritonVAE, "name": "Patch Triton VAE"},
-    })
-except Exception:
-    logging.warning("KJNodes: PatchTritonVAE node could not be imported. PatchTritonVAE will be unavailable.", exc_info=True)
+import importlib.util
+
+if importlib.util.find_spec("triton") is not None:
+    try:
+        from .nodes.triton_vae import PatchTritonVAE
+        NODE_CONFIG.update({
+            "PatchTritonVAE": {"class": PatchTritonVAE, "name": "Patch Triton VAE"},
+        })
+    except Exception:
+        logging.warning("KJNodes: PatchTritonVAE node could not be imported. PatchTritonVAE will be unavailable.", exc_info=True)
+else:
+    logging.info("KJNodes: triton not installed, skipping PatchTritonVAE node.")
 
 def generate_node_mappings(node_config):
     node_class_mappings = {}


### PR DESCRIPTION
## Summary

- Check whether the `triton` package is available before importing `PatchTritonVAE`
- Avoid startup warning tracebacks on non-CUDA environments (e.g. AMD ROCm) where Triton is not installed
- When Triton is missing, log an info message and skip the node registration instead of attempting import

## Motivation

`PatchTritonVAE` depends on Triton, which is typically unavailable outside NVIDIA CUDA setups. The current unconditional import attempt triggers a warning with full traceback on every startup, even though the node cannot be used in those environments.

## Test plan

- [x] Start ComfyUI without Triton installed: no warning traceback; info log about skipping PatchTritonVAE
- [ ] Start ComfyUI with Triton installed: PatchTritonVAE node still registers normally
- [x] Other KJNodes nodes continue to load as before