### PR TITLE
Fix: pad V to CTA_K=128 in H3 mem-eff sage sm90 branch (fixes crash with long prompts)

### DIFF
--- a/nodes/ltxv_nodes.py
+++ b/nodes/ltxv_nodes.py
@@ -1919,6 +1919,16 @@ def _sageattn_int8_fp8_nhd(qkv, dtype):
         k.sub_(k.mean(dim=1, keepdim=True))
         q_int8, q_scale, k_int8, k_scale = _per_thread_int8_i64(q, k, tensor_layout=tensor_layout, BLKQ=64, WARPQ=16, BLKK=128, WARPK=128)
         del q, k
+        # sageattention sm90 kernel requires kv_len padded to CTA_K=128, but
+        # per_channel_fp8 only pads to 64 (upstream TODO in sageattention/quant.py).
+        # sageattention.core.sageattn_qk_int8_pv_fp8_cuda_sm90 handles this at the
+        # top-level API; mirror that pad here so kv_len%128 != 0 (e.g. MiniMax H3
+        # with long text prompts) does not trigger a C++ assertion abort.
+        seq_dim = 1  # NHD layout
+        kv_len = v.size(seq_dim)
+        v_pad_len = 128 - (kv_len % 128) if kv_len % 128 != 0 else 0
+        if v_pad_len > 0:
+            v = torch.cat([v, torch.zeros(v.size(0), v_pad_len, v.size(2), v.size(3), dtype=v.dtype, device=v.device)], dim=seq_dim)
         v_fp8, v_scale, _ = per_channel_fp8(v, tensor_layout=tensor_layout, smooth_v=False)
         del v
         o = torch.empty(q_int8.size(), dtype=dtype, device=q_int8.device)


### PR DESCRIPTION
`MiniMaxH3MemoryEfficientSageAttentionPatch` crashes with a C++ assertion abort when MiniMax H3 is run with long prompts on SM90 (H20 / H100 / H800). The sm90 sage kernel asserts `value.size(3) >= div_ceil(kv_len, CTA_K) * CTA_K` with `CTA_K = 128`, but `sageattention.per_channel_fp8` only pads `kv_len` to a multiple of 64. When `kv_len % 128 ∈ [65, 127]` the assertion aborts the entire ComfyUI process (Fatal Python error).

This affects H3 prompts written to the [official prompt writing guide](https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/main/docs/VIDEO_PROMPT_WRITING_GUIDE_base_en.md) (T2VA / Ref2VA with shot timelines, `overall_soundscape`, `non_diegetic_music`) — those prompts run 100+ words and typically push the packed `text + audio + video` kv_len into the failing range. Short prompts (< 50 words) happen to land on kv_len values that pass the check.

## Reproduction

- H20 (SM90) + `minimax_h3_fl2va_pruned_fp8_scaled.safetensors` + this repo's `MiniMaxH3MemoryEfficientSageAttentionPatch` + `Larryvrh/ComfyUI-MiniMax-H3-Turbo`
- Short prompt (~40 words): runs
- Official long T2VA prompt (~130 words with `[Shot 1]`/`[Shot 2]` + soundscape + music sections): crashes with
```
python: SageAttention/csrc/qattn/qk_int_sv_f8_cuda_sm90.cu:857:
Assertion `value.size(3) >= div_ceil(kv_len, CTA_K) * CTA_K' failed.
```

Same failure with any `kv_len` such that `kv_len % 128 ∈ [65, 127]`.

## Root cause

`sageattention/quant.py :: per_channel_fp8` pads to 64:
```python
padded_len = (kv_len + 63) // 64 * 64
```

The sm90 kernel requires 128 alignment. The upstream sageattention top-level API `sageattn_qk_int8_pv_fp8_cuda_sm90` [handles this by padding V to 128 before calling per_channel_fp8](https://github.com/thu-ml/SageAttention/blob/main/sageattention/core.py#L972-L980) (with the comment `# TODO: modify per_channel_fp8 kernel to handle this`). `_sageattn_int8_fp8_nhd` in this repo copies the direct-kernel-call pattern but skips that pad step.

I've also opened a separate issue upstream at thu-ml/SageAttention asking them to fix `per_channel_fp8` so this workaround is no longer needed.

## Fix

Copy the exact same V-pad-to-128 logic from `sageattention.core` into the sm90 branch of `_sageattn_int8_fp8_nhd`.

## Verification

On H20 with this patch:
- Short prompt regression: 48s, unchanged (same seed produces identical output; pad-to-128 is a strict superset of pad-to-64 when both already agree)
- Official long T2VA prompt: previously aborted the entire ComfyUI process, now completes in 48s with normal visual quality

## Notes

- Only touches the `sm90` branch. `sm89` / `sm120` call different kernels; I did not test whether they have the same latent bug (their `CTA_K` may differ or `per_channel_fp8` may not be reached). Happy to add matching pads if you confirm they do.
