### PR TITLE
Fix arbitrary code execution in VisualizeCUDAMemoryHistory (unsafe pickle.load)

### DIFF
--- a/nodes/model_optimization_nodes.py
+++ b/nodes/model_optimization_nodes.py
@@ -5,6 +5,7 @@ import torch
 import importlib
 import math
 import datetime
+import pickle
 from tqdm import tqdm
 
 import folder_paths
@@ -1908,6 +1909,39 @@ try:
 except ImportError:
     PromptServer = None
 
+
+class _RestrictedSnapshotUnpickler(pickle.Unpickler):
+    """Unpickler that refuses to import arbitrary globals.
+
+    A CUDA memory snapshot produced by ``torch.cuda.memory._dump_snapshot`` is pure
+    data (nested dict/list/tuple and str/int/float/bool/None), none of which requires
+    importing a class or function during unpickling. We therefore reject every global
+    lookup except a small allowlist of harmless container reconstructors. Legitimate
+    snapshots load unchanged, while a crafted "snapshot" file cannot execute code
+    (e.g. a ``__reduce__`` payload calling ``exec``/``os.system``) because that path
+    goes through ``find_class``.
+    """
+
+    # These reconstructors only build data containers and cannot execute code.
+    _ALLOWED_GLOBALS = {
+        "builtins": {"dict", "list", "tuple", "set", "frozenset", "bytearray", "complex"},
+        "collections": {"OrderedDict"},
+    }
+
+    def find_class(self, module, name):
+        if name in self._ALLOWED_GLOBALS.get(module, frozenset()):
+            return super().find_class(module, name)
+        raise pickle.UnpicklingError(
+            f"Refusing to load disallowed global '{module}.{name}' from CUDA memory "
+            "snapshot; the file is not a trusted snapshot and may be malicious."
+        )
+
+
+def _safe_load_cuda_snapshot(file_obj):
+    """Deserialize a CUDA memory-history snapshot without allowing code execution."""
+    return _RestrictedSnapshotUnpickler(file_obj).load()
+
+
 class VisualizeCUDAMemoryHistory():
     @classmethod
     def INPUT_TYPES(s):
@@ -1927,7 +1961,6 @@ class VisualizeCUDAMemoryHistory():
     OUTPUT_NODE = True
 
     def visualize(self, snapshot_path, unique_id):
-        import pickle
         from torch.cuda import _memory_viz
         import uuid
 
@@ -1935,7 +1968,7 @@ class VisualizeCUDAMemoryHistory():
         output_dir = get_output_directory()
 
         with open(snapshot_path, "rb") as f:
-            snapshot = pickle.load(f)
+            snapshot = _safe_load_cuda_snapshot(f)
 
         html = _memory_viz.trace_plot(snapshot)
         html_filename = f"cuda_memory_history_{uuid.uuid4().hex}.html"


### PR DESCRIPTION
## Summary

`VisualizeCUDAMemoryHistory.visualize()` loads a user-supplied snapshot file with
`pickle.load()`. Because `pickle` invokes an object's `__reduce__` during unpickling,
a maliciously crafted `.pt` "CUDA memory snapshot" leads to **arbitrary code execution**
as soon as the node runs — no GPU, CUDA, or valid snapshot data required, since the
payload fires before the data is ever used.

**File:** `nodes/model_optimization_nodes.py` · **Node:** `VisualizeCUDAMemoryHistory` (`KJNodes/memory`)

```python
# before
with open(snapshot_path, "rb") as f:
    snapshot = pickle.load(f)      # runs attacker-controlled __reduce__
```

## Demo

https://github.com/user-attachments/assets/87e5d40f-94b7-49c6-97f8-9501dca78a7e

## Impact

ComfyUI workflows are commonly shared as JSON with companion asset files. A user who
loads a shared "CUDA memory visualization" workflow and runs it — pointing the node at a
bundled or downloaded snapshot — is compromised. `snapshot_path` is a plain workflow
string, so the malicious path/file can be pre-filled inside the shared workflow.

- **Class:** CWE-502, Deserialization of Untrusted Data
- **Effect:** Remote code execution in the ComfyUI process (full user-level access)

## Fix

Load snapshots through a restricted `pickle.Unpickler` that rejects every global import
except a small allowlist of harmless data-container reconstructors.

A real snapshot from `torch.cuda.memory._dump_snapshot()` is **pure data** — nested
`dict`/`list`/`tuple` plus `str`/`int`/`float`/`bool`/`None` — none of which requires
importing a class or function. Those deserialize via dedicated pickle opcodes that never
touch `find_class`. Only `__reduce__`-based payloads (`exec`, `os.system`, `subprocess`,
…) go through `find_class`, and those are now refused.

**Functionality is preserved:** legitimate snapshots load unchanged; only code-execution
payloads are blocked.

```python
class _RestrictedSnapshotUnpickler(pickle.Unpickler):
    _ALLOWED_GLOBALS = {
        "builtins": {"dict", "list", "tuple", "set", "frozenset", "bytearray", "complex"},
        "collections": {"OrderedDict"},
    }
    def find_class(self, module, name):
        if name in self._ALLOWED_GLOBALS.get(module, frozenset()):
            return super().find_class(module, name)
        raise pickle.UnpicklingError(
            f"Refusing to load disallowed global '{module}.{name}' from CUDA memory "
            "snapshot; the file is not a trusted snapshot and may be malicious."
        )
```

## Verification

- A representative snapshot matching the shape of `torch.cuda.memory._snapshot()`
  round-trips through the new loader **unchanged**.
- A `__reduce__` payload (`exec("...")`) is **rejected** with
  `UnpicklingError: Refusing to load disallowed global 'builtins.exec' ...` and never
  executes.
- Control check: the previous unrestricted `pickle.loads` **does** execute the same
  payload — confirming the issue is real and this change is what stops it.

## Note

Pickle cannot be made fully safe for untrusted input; this allowlist neutralizes the
code-execution vectors while keeping the feature working. As optional defense in depth,
`snapshot_path` could additionally be constrained to ComfyUI's input/output directories,
with documentation that only self-generated snapshots should be visualized.



